### PR TITLE
Dry run option

### DIFF
--- a/R/dry_run.R
+++ b/R/dry_run.R
@@ -4,13 +4,12 @@ dry_runner <- function(dry_run = FALSE) {
   function(msg, expr, code = NULL) {
     env <- parent.frame()
     if (!dry_run) {
-      eval(substitute(expr), envir = env)
+      force(expr)
       return(invisible(NULL))
     }
 
     msg <- cli::format_inline(msg, .envir = env)
     if (!is.null(code)) {
-      code <- cli::format_inline(code, .envir = env)
       msg <- paste0(msg, ": ", code)
     }
     cli::cli_alert_info("Would {msg}.")
@@ -19,31 +18,33 @@ dry_runner <- function(dry_run = FALSE) {
 }
 
 dry_code_attach <- function(pkg) {
-  cli::format_inline('stanflow:::.same_library("{pkg}")')
+  sprintf("stanflow:::.same_library(%s)", deparse1(pkg))
 }
 
-dry_code_install_package <- function(pkg) {
-  cli::format_inline(
-    'utils::install.packages("{pkg}", repos = stanflow::stan_repos(dev), quiet = TRUE)'
+dry_code_install_package <- function(pkg, dev) {
+  sprintf(
+    "utils::install.packages(%s, repos = stanflow::stan_repos(%s), quiet = TRUE)",
+    deparse1(pkg),
+    deparse1(dev)
   )
 }
 
 dry_code_mc_cores <- function(cores) {
-  cli::format_inline("options(mc.cores = {cores})")
+  sprintf("options(mc.cores = %s)", deparse1(cores))
 }
 
 dry_code_rstan <- function(cores, rstan_auto_write) {
-  cli::format_inline(
-    "options(mc.cores = {cores}); rstan::rstan_options(auto_write = {rstan_auto_write})"
+  sprintf(
+    "%s; rstan::rstan_options(auto_write = %s)",
+    dry_code_mc_cores(cores),
+    deparse1(rstan_auto_write)
   )
 }
 
 dry_code_brms <- function(cores, brms_backend) {
-  cli::format_inline(
-    'options(mc.cores = {cores}); options(brms.backend = "{brms_backend}")'
+  sprintf(
+    "%s; options(brms.backend = %s)",
+    dry_code_mc_cores(cores),
+    deparse1(brms_backend)
   )
-}
-
-dry_code_package_vector <- function(pkgs) {
-  paste0("c(", paste(vapply(pkgs, deparse, character(1)), collapse = ", "), ")")
 }

--- a/R/dry_run.R
+++ b/R/dry_run.R
@@ -16,7 +16,7 @@ dry_runner <- function(dry_run = FALSE) {
   }
 }
 
-dry_code_attach <- \(pkg) sprintf("stanflow:::.same_library(%s)", deparse1(pkg))
+dry_code_attach <- \(pkg) sprintf("library(%s)", deparse1(pkg))
 dry_code_mc_cores <- \(cores) sprintf("options(mc.cores = %s)", deparse1(cores))
 dry_code_install_package <- function(pkg, dev, quiet) {
   sprintf(

--- a/R/dry_run.R
+++ b/R/dry_run.R
@@ -16,7 +16,18 @@ dry_runner <- function(dry_run = FALSE) {
   }
 }
 
-dry_code_attach <- \(pkg) sprintf("library(%s)", deparse1(pkg))
+dry_code_attach <- function(pkg) {
+  sprintf(
+    paste0(
+      "library(%s, lib.loc = if (%s %%in%% loadedNamespaces()) ",
+      "dirname(getNamespaceInfo(%s, \"path\")), character.only = TRUE, ",
+      "warn.conflicts = FALSE)"
+    ),
+    deparse1(pkg),
+    deparse1(pkg),
+    deparse1(pkg)
+  )
+}
 dry_code_mc_cores <- \(cores) sprintf("options(mc.cores = %s)", deparse1(cores))
 dry_code_install_package <- function(pkg, dev, quiet) {
   sprintf(

--- a/R/dry_run.R
+++ b/R/dry_run.R
@@ -1,0 +1,49 @@
+dry_runner <- function(dry_run = FALSE) {
+  force(dry_run)
+
+  function(msg, expr, code = NULL) {
+    env <- parent.frame()
+    if (!dry_run) {
+      eval(substitute(expr), envir = env)
+      return(invisible(NULL))
+    }
+
+    msg <- cli::format_inline(msg, .envir = env)
+    if (!is.null(code)) {
+      code <- cli::format_inline(code, .envir = env)
+      msg <- paste0(msg, ": ", code)
+    }
+    cli::cli_alert_info("Would {msg}.")
+    invisible(NULL)
+  }
+}
+
+dry_code_attach <- function(pkg) {
+  cli::format_inline('stanflow:::.same_library("{pkg}")')
+}
+
+dry_code_install_package <- function(pkg) {
+  cli::format_inline(
+    'utils::install.packages("{pkg}", repos = stanflow::stan_repos(dev), quiet = TRUE)'
+  )
+}
+
+dry_code_mc_cores <- function(cores) {
+  cli::format_inline("options(mc.cores = {cores})")
+}
+
+dry_code_rstan <- function(cores, rstan_auto_write) {
+  cli::format_inline(
+    "options(mc.cores = {cores}); rstan::rstan_options(auto_write = {rstan_auto_write})"
+  )
+}
+
+dry_code_brms <- function(cores, brms_backend) {
+  cli::format_inline(
+    'options(mc.cores = {cores}); options(brms.backend = "{brms_backend}")'
+  )
+}
+
+dry_code_package_vector <- function(pkgs) {
+  paste0("c(", paste(vapply(pkgs, deparse, character(1)), collapse = ", "), ")")
+}

--- a/R/interfaces.R
+++ b/R/interfaces.R
@@ -22,7 +22,7 @@
 #' @param reinstall Logical. If `TRUE`, forces re-installation.
 #' @param check_updates Logical. If `TRUE`, checks for CmdStan updates.
 #' @param rstan_auto_write Logical. If `TRUE` (default), sets `rstan::rstan_options(auto_write = TRUE)`
-#' @param dry_run Logical. If `TRUE`, prints commands without executing them.
+#' @param dry_run Logical. If `TRUE`, prints commands without executing them. Dry-run output is shown even when `quiet = TRUE`.
 #' @return Returns attached package names invisibly.
 #' @export
 #' @examples

--- a/R/interfaces.R
+++ b/R/interfaces.R
@@ -22,6 +22,9 @@
 #' @param reinstall Logical. If `TRUE`, forces re-installation.
 #' @param check_updates Logical. If `TRUE`, checks for CmdStan updates.
 #' @param rstan_auto_write Logical. If `TRUE` (default), sets `rstan::rstan_options(auto_write = TRUE)`
+#' @param dry_run Logical. If `TRUE`, prints the setup actions that would run
+#'   without installing packages, attaching packages, changing options, fixing
+#'   the toolchain, or installing CmdStan. Defaults to `FALSE`.
 #' @return Returns attached package names invisibly.
 #' @export
 #' @examples
@@ -43,7 +46,8 @@ setup_interface <- function(
   check_updates = FALSE,
   dev = FALSE,
   brms_backend = c("cmdstanr", "rstan"),
-  rstan_auto_write = TRUE
+  rstan_auto_write = TRUE,
+  dry_run = FALSE
 ) {
   local_cli_quiet(quiet)
 
@@ -86,11 +90,17 @@ setup_interface <- function(
 
   for (pkg in interface) {
     if (!is_installed(pkg) || reinstall) {
-      install_backend_package(pkg, dev, quiet, force, reinstall)
+      install_backend_package(
+        pkg,
+        dev,
+        quiet,
+        force,
+        reinstall,
+        dry_run = dry_run
+      )
     }
 
-    cli::cli_alert_info("Attaching {.pkg {pkg}}...")
-    suppressPackageStartupMessages(.same_library(pkg))
+    attach_backend_package(pkg, dry_run)
 
     switch(
       pkg,
@@ -99,15 +109,20 @@ setup_interface <- function(
         force,
         reinstall,
         check_updates,
-        cores
+        cores,
+        dry_run = dry_run
       ),
-      "rstan" = setup_rstan(quiet, cores, rstan_auto_write),
-      "brms" = setup_brms(quiet, brms_backend, cores),
-      "rstanarm" = setup_rstanarm(quiet, cores)
+      "rstan" = setup_rstan(quiet, cores, rstan_auto_write, dry_run),
+      "brms" = setup_brms(quiet, brms_backend, cores, dry_run),
+      "rstanarm" = setup_rstanarm(quiet, cores, dry_run)
     )
   }
 
   attached_pkgs <- unique(interface)
+  if (dry_run) {
+    return(invisible(attached_pkgs))
+  }
+
   attached_pkgs_cli <- paste0("{.pkg ", attached_pkgs, "}", collapse = ", ")
   pkg_count <- cli::qty(length(attached_pkgs))
   pkg_phrase <- cli::pluralize("{pkg_count}{?is/are}")
@@ -121,8 +136,16 @@ setup_interface <- function(
 }
 
 # nocov start
-install_backend_package <- function(pkg, dev, quiet, force, reinstall) {
+install_backend_package <- function(
+  pkg,
+  dev,
+  quiet,
+  force,
+  reinstall,
+  dry_run = FALSE
+) {
   local_cli_quiet(quiet)
+  run_side_effect <- dry_runner(dry_run)
 
   if (reinstall) {
     cli::cli_alert_warning(
@@ -132,7 +155,7 @@ install_backend_package <- function(pkg, dev, quiet, force, reinstall) {
     cli::cli_alert_warning("Package {.pkg {pkg}} is not installed.")
   }
 
-  if (!is_interactive_session() && !force) {
+  if (!dry_run && !is_interactive_session() && !force) {
     cli::cli_abort(
       c(
         "Package {.pkg {pkg}} is missing.",
@@ -142,7 +165,7 @@ install_backend_package <- function(pkg, dev, quiet, force, reinstall) {
     )
   }
 
-  if (is_interactive_session() && !force) {
+  if (!dry_run && is_interactive_session() && !force) {
     title <- if (dev) {
       "Install from Stan Universe (Dev)?"
     } else {
@@ -154,9 +177,28 @@ install_backend_package <- function(pkg, dev, quiet, force, reinstall) {
     }
   }
 
-  cli::cli_progress_step("Installing {.pkg {pkg}}...")
-  utils::install.packages(pkg, repos = stan_repos(dev), quiet = TRUE)
-  cli::cli_progress_done()
+  run_side_effect(
+    "install {.pkg {pkg}}",
+    {
+      cli::cli_progress_step("Installing {.pkg {pkg}}...")
+      utils::install.packages(pkg, repos = stan_repos(dev), quiet = TRUE)
+      cli::cli_progress_done()
+    },
+    code = dry_code_install_package(pkg)
+  )
+}
+
+attach_backend_package <- function(pkg, dry_run = FALSE) {
+  run_side_effect <- dry_runner(dry_run)
+
+  run_side_effect(
+    "attach {.pkg {pkg}}",
+    {
+      cli::cli_alert_info("Attaching {.pkg {pkg}}...")
+      suppressPackageStartupMessages(.same_library(pkg))
+    },
+    code = dry_code_attach(pkg)
+  )
 }
 
 #' Setup cmdstanr and CmdStan
@@ -185,13 +227,21 @@ setup_cmdstanr <- function(
   force,
   reinstall = FALSE,
   check_updates = TRUE,
-  cores
+  cores,
+  dry_run = FALSE
 ) {
   local_cli_quiet(quiet)
+  run_side_effect <- dry_runner(dry_run)
 
   toolchain_ok <- tryCatch(
     {
-      cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = quiet)
+      run_side_effect(
+        "check and fix the CmdStan toolchain",
+        {
+          cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = quiet)
+        },
+        code = "cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = quiet)"
+      )
       TRUE
     },
     error = function(e) {
@@ -208,6 +258,11 @@ setup_cmdstanr <- function(
         "i" = "Re-run {.code cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = FALSE)} for detailed diagnostics."
       )
     )
+  }
+
+  if (dry_run) {
+    set_mc_cores(run_side_effect, cores, "cmdstanr")
+    return(invisible(NULL))
   }
 
   cmdstan_ready <- FALSE
@@ -265,10 +320,7 @@ setup_cmdstanr <- function(
   } else if (needs_update) {
     action_msg <- sprintf("Update available: v%s -> v%s", local_ver, latest_ver)
   } else {
-    options(mc.cores = cores)
-    cli::cli_alert_info(
-      "Configured {.pkg cmdstanr}: set {.code options(mc.cores = {cores})}"
-    )
+    set_mc_cores(run_side_effect, cores, "cmdstanr")
     return(invisible(TRUE))
   }
 
@@ -305,16 +357,17 @@ setup_cmdstanr <- function(
     }
   }
 
-  cli::cli_process_start("Installing CmdStan (this can take some time)...")
-
-  cmdstanr::install_cmdstan(quiet = quiet, overwrite = TRUE, cores = cores)
-
-  cli::cli_process_done()
-
-  options(mc.cores = cores)
-  cli::cli_alert_info(
-    "Configured {.pkg cmdstanr}: set {.code options(mc.cores = {cores})}"
+  run_side_effect(
+    "install CmdStan",
+    {
+      cli::cli_process_start("Installing CmdStan (this can take some time)...")
+      cmdstanr::install_cmdstan(quiet = quiet, overwrite = TRUE, cores = cores)
+      cli::cli_process_done()
+    },
+    code = "cmdstanr::install_cmdstan(quiet = quiet, overwrite = TRUE, cores = cores)"
   )
+
+  set_mc_cores(run_side_effect, cores, "cmdstanr")
   invisible(NULL)
 }
 # nocov end
@@ -332,16 +385,27 @@ setup_cmdstanr <- function(
 #' \dontrun{
 #' setup_rstan(quiet = TRUE, cores = 2, rstan_auto_write = TRUE)
 #' }
-setup_rstan <- function(quiet, cores, rstan_auto_write) {
+setup_rstan <- function(
+  quiet,
+  cores,
+  rstan_auto_write,
+  dry_run = FALSE
+) {
   local_cli_quiet(quiet)
+  run_side_effect <- dry_runner(dry_run)
 
-  options(mc.cores = cores)
-  rstan::rstan_options(auto_write = rstan_auto_write)
-
-  cli::format_inline(
-    "Configured {.pkg rstan}: set {.code options(mc.cores = {cores})} and {.code rstan::rstan_options(auto_write = {rstan_auto_write})}"
-  ) |>
-    cli::cli_alert_info()
+  run_side_effect(
+    "configure {.pkg rstan}: set {.code options(mc.cores = {cores})} and {.code rstan::rstan_options(auto_write = {rstan_auto_write})}",
+    {
+      options(mc.cores = cores)
+      rstan::rstan_options(auto_write = rstan_auto_write)
+      cli::format_inline(
+        "Configured {.pkg rstan}: set {.code options(mc.cores = {cores})} and {.code rstan::rstan_options(auto_write = {rstan_auto_write})}"
+      ) |>
+        cli::cli_alert_info()
+    },
+    code = dry_code_rstan(cores, rstan_auto_write)
+  )
   invisible(NULL)
 }
 
@@ -358,15 +422,26 @@ setup_rstan <- function(quiet, cores, rstan_auto_write) {
 #' \dontrun{
 #' setup_brms(quiet = TRUE, brms_backend = "cmdstanr", cores = 2)
 #' }
-setup_brms <- function(quiet, brms_backend, cores) {
+setup_brms <- function(
+  quiet,
+  brms_backend,
+  cores,
+  dry_run = FALSE
+) {
   local_cli_quiet(quiet)
+  run_side_effect <- dry_runner(dry_run)
   brms_backend <- match.arg(brms_backend, c("cmdstanr", "rstan"))
 
-  options(mc.cores = cores)
-  options(brms.backend = brms_backend)
-
-  cli::cli_alert_info(
-    "Configured {.pkg brms}: set {.code options(mc.cores = {cores})} and {.code options(brms.backend = '{brms_backend}')}"
+  run_side_effect(
+    "configure {.pkg brms}: set {.code options(mc.cores = {cores})} and {.code options(brms.backend = '{brms_backend}')}",
+    {
+      options(mc.cores = cores)
+      options(brms.backend = brms_backend)
+      cli::cli_alert_info(
+        "Configured {.pkg brms}: set {.code options(mc.cores = {cores})} and {.code options(brms.backend = '{brms_backend}')}"
+      )
+    },
+    code = dry_code_brms(cores, brms_backend)
   )
   invisible(NULL)
 }
@@ -384,13 +459,28 @@ setup_brms <- function(quiet, brms_backend, cores) {
 #' \dontrun{
 #' setup_rstanarm(quiet = TRUE, cores = 2)
 #' }
-setup_rstanarm <- function(quiet, cores) {
+setup_rstanarm <- function(
+  quiet,
+  cores,
+  dry_run = FALSE
+) {
   local_cli_quiet(quiet)
+  run_side_effect <- dry_runner(dry_run)
 
-  options(mc.cores = cores)
-
-  cli::cli_alert_info(
-    "Configured {.pkg rstanarm}: set {.code options(mc.cores = {cores})}"
-  )
+  set_mc_cores(run_side_effect, cores, "rstanarm")
   invisible(NULL)
+}
+
+set_mc_cores <- function(run_side_effect, cores, pkg) {
+  run_side_effect(
+    "configure {.pkg {pkg}}: set {.code options(mc.cores = {cores})}",
+    {
+      options(mc.cores = cores)
+      cli::format_inline(
+        "Configured {.pkg {pkg}}: set {.code options(mc.cores = {cores})}"
+      ) |>
+        cli::cli_alert_info()
+    },
+    code = dry_code_mc_cores(cores)
+  )
 }

--- a/R/interfaces.R
+++ b/R/interfaces.R
@@ -49,7 +49,7 @@ setup_interface <- function(
   rstan_auto_write = TRUE,
   dry_run = FALSE
 ) {
-  local_cli_quiet(quiet)
+  local_cli_quiet(quiet && !dry_run)
 
   if (missing(interface)) {
     cli::cli_abort(
@@ -144,7 +144,7 @@ install_backend_package <- function(
   reinstall,
   dry_run = FALSE
 ) {
-  local_cli_quiet(quiet)
+  local_cli_quiet(quiet && !dry_run)
   run_side_effect <- dry_runner(dry_run)
 
   if (reinstall) {
@@ -155,7 +155,13 @@ install_backend_package <- function(
     cli::cli_alert_warning("Package {.pkg {pkg}} is not installed.")
   }
 
-  if (!dry_run && !is_interactive_session() && !force) {
+  if (!is_interactive_session() && !force) {
+    if (dry_run) {
+      cli::cli_alert_warning(
+        "Would not install {.pkg {pkg}} in a non-interactive session because {.code force = FALSE}."
+      )
+      return(invisible(NULL))
+    }
     cli::cli_abort(
       c(
         "Package {.pkg {pkg}} is missing.",
@@ -165,7 +171,13 @@ install_backend_package <- function(
     )
   }
 
-  if (!dry_run && is_interactive_session() && !force) {
+  if (is_interactive_session() && !force) {
+    if (dry_run) {
+      cli::cli_alert_info(
+        "Would ask before installing {.pkg {pkg}}."
+      )
+      return(invisible(NULL))
+    }
     title <- if (dev) {
       "Install from Stan Universe (Dev)?"
     } else {
@@ -184,7 +196,7 @@ install_backend_package <- function(
       utils::install.packages(pkg, repos = stan_repos(dev), quiet = TRUE)
       cli::cli_progress_done()
     },
-    code = dry_code_install_package(pkg)
+    code = dry_code_install_package(pkg, dev)
   )
 }
 
@@ -230,7 +242,7 @@ setup_cmdstanr <- function(
   cores,
   dry_run = FALSE
 ) {
-  local_cli_quiet(quiet)
+  local_cli_quiet(quiet && !dry_run)
   run_side_effect <- dry_runner(dry_run)
 
   toolchain_ok <- tryCatch(
@@ -240,7 +252,10 @@ setup_cmdstanr <- function(
         {
           cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = quiet)
         },
-        code = "cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = quiet)"
+        code = sprintf(
+          "cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = %s)",
+          deparse1(quiet)
+        )
       )
       TRUE
     },
@@ -258,11 +273,6 @@ setup_cmdstanr <- function(
         "i" = "Re-run {.code cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = FALSE)} for detailed diagnostics."
       )
     )
-  }
-
-  if (dry_run) {
-    set_mc_cores(run_side_effect, cores, "cmdstanr")
-    return(invisible(NULL))
   }
 
   cmdstan_ready <- FALSE
@@ -328,10 +338,22 @@ setup_cmdstanr <- function(
 
   if (!is_interactive_session() && !force) {
     if (needs_update && !needs_install) {
+      if (dry_run) {
+        cli::cli_alert_info(
+          "Would skip update in non-interactive mode (set {.code force = TRUE} to upgrade)."
+        )
+        return(invisible(NULL))
+      }
       cli::cli_alert_info(
         "Skipping update in non-interactive mode (set {.code force = TRUE} to upgrade)."
       )
       return(invisible(TRUE))
+    }
+    if (dry_run) {
+      cli::cli_alert_warning(
+        "Would not install CmdStan in a non-interactive session because {.code force = FALSE}."
+      )
+      return(invisible(NULL))
     }
     cli::cli_abort(
       c(
@@ -343,6 +365,12 @@ setup_cmdstanr <- function(
   }
 
   if (is_interactive_session() && !force) {
+    if (dry_run) {
+      cli::cli_alert_info(
+        "Would ask before installing/upgrading CmdStan."
+      )
+      return(invisible(NULL))
+    }
     title <- if (needs_install) {
       "Download and compile CmdStan now?"
     } else {
@@ -364,7 +392,11 @@ setup_cmdstanr <- function(
       cmdstanr::install_cmdstan(quiet = quiet, overwrite = TRUE, cores = cores)
       cli::cli_process_done()
     },
-    code = "cmdstanr::install_cmdstan(quiet = quiet, overwrite = TRUE, cores = cores)"
+    code = sprintf(
+      "cmdstanr::install_cmdstan(quiet = %s, overwrite = TRUE, cores = %s)",
+      deparse1(quiet),
+      deparse1(cores)
+    )
   )
 
   set_mc_cores(run_side_effect, cores, "cmdstanr")
@@ -391,7 +423,7 @@ setup_rstan <- function(
   rstan_auto_write,
   dry_run = FALSE
 ) {
-  local_cli_quiet(quiet)
+  local_cli_quiet(quiet && !dry_run)
   run_side_effect <- dry_runner(dry_run)
 
   run_side_effect(
@@ -428,7 +460,7 @@ setup_brms <- function(
   cores,
   dry_run = FALSE
 ) {
-  local_cli_quiet(quiet)
+  local_cli_quiet(quiet && !dry_run)
   run_side_effect <- dry_runner(dry_run)
   brms_backend <- match.arg(brms_backend, c("cmdstanr", "rstan"))
 
@@ -464,7 +496,7 @@ setup_rstanarm <- function(
   cores,
   dry_run = FALSE
 ) {
-  local_cli_quiet(quiet)
+  local_cli_quiet(quiet && !dry_run)
   run_side_effect <- dry_runner(dry_run)
 
   set_mc_cores(run_side_effect, cores, "rstanarm")

--- a/R/interfaces.R
+++ b/R/interfaces.R
@@ -277,12 +277,13 @@ setup_cmdstanr <- function(
   if (cmdstan_ready && check_updates) {
     if (dry_run) {
       cli::cli_alert_info("Would check for CmdStan updates.")
-    }
-    latest_ver <- try_fetch_latest_cmdstan_version()
-    if (is.null(latest_ver)) {
-      cli::cli_alert_warning(
-        "Could not check for CmdStan updates; using installed CmdStan v{local_ver}."
-      )
+    } else {
+      latest_ver <- try_fetch_latest_cmdstan_version()
+      if (is.null(latest_ver)) {
+        cli::cli_alert_warning(
+          "Could not check for CmdStan updates; using installed CmdStan v{local_ver}."
+        )
+      }
     }
   }
 

--- a/R/interfaces.R
+++ b/R/interfaces.R
@@ -22,8 +22,10 @@
 #' @param reinstall Logical. If `TRUE`, forces re-installation.
 #' @param check_updates Logical. If `TRUE`, checks for CmdStan updates.
 #' @param rstan_auto_write Logical. If `TRUE` (default), sets `rstan::rstan_options(auto_write = TRUE)`
-#' @param dry_run Logical. If `TRUE`, prints commands without executing them. Dry-run output is shown even when `quiet = TRUE`.
-#' @return Returns attached package names invisibly.
+#' @param dry_run Logical. If `TRUE`, previews mutating setup actions without
+#'   installing, attaching, changing options, or prompting. Dry-run output is
+#'   shown even when `quiet = TRUE`.
+#' @return Returns attached package names invisibly. With `dry_run = TRUE`, returns the package names that would be attached.
 #' @export
 #' @examples
 #' \dontrun{
@@ -276,7 +278,9 @@ setup_cmdstanr <- function(
   latest_ver <- NULL
   if (cmdstan_ready && check_updates) {
     if (dry_run) {
-      cli::cli_alert_info("Would check for CmdStan updates.")
+      cli::cli_alert_info(
+        "Would install or upgrade CmdStan if a newer release is found."
+      )
     } else {
       latest_ver <- try_fetch_latest_cmdstan_version()
       if (is.null(latest_ver)) {

--- a/R/interfaces.R
+++ b/R/interfaces.R
@@ -22,9 +22,7 @@
 #' @param reinstall Logical. If `TRUE`, forces re-installation.
 #' @param check_updates Logical. If `TRUE`, checks for CmdStan updates.
 #' @param rstan_auto_write Logical. If `TRUE` (default), sets `rstan::rstan_options(auto_write = TRUE)`
-#' @param dry_run Logical. If `TRUE`, prints the setup actions that would run
-#'   without installing packages, attaching packages, changing options, fixing
-#'   the toolchain, or installing CmdStan. Defaults to `FALSE`.
+#' @param dry_run Logical. If `TRUE`, prints commands without executing them.
 #' @return Returns attached package names invisibly.
 #' @export
 #' @examples
@@ -263,11 +261,6 @@ setup_cmdstanr <- function(
     )
   }
 
-  if (dry_run) {
-    set_mc_cores(run_side_effect, cores, "cmdstanr")
-    return(invisible(NULL))
-  }
-
   cmdstan_ready <- FALSE
   local_ver <- NULL
   tryCatch(
@@ -282,6 +275,9 @@ setup_cmdstanr <- function(
 
   latest_ver <- NULL
   if (cmdstan_ready && check_updates) {
+    if (dry_run) {
+      cli::cli_alert_info("Would check for CmdStan updates.")
+    }
     latest_ver <- try_fetch_latest_cmdstan_version()
     if (is.null(latest_ver)) {
       cli::cli_alert_warning(
@@ -306,24 +302,12 @@ setup_cmdstanr <- function(
 
   cli::cli_alert_warning(action_msg)
 
-  if (!is_interactive_session() && !force) {
+  if (!dry_run && !is_interactive_session() && !force) {
     if (needs_update && !needs_install) {
-      if (dry_run) {
-        cli::cli_alert_info(
-          "Would skip update in non-interactive mode (set {.code force = TRUE} to upgrade)."
-        )
-        return(invisible(NULL))
-      }
       cli::cli_alert_info(
         "Skipping update in non-interactive mode (set {.code force = TRUE} to upgrade)."
       )
       return(invisible(TRUE))
-    }
-    if (dry_run) {
-      cli::cli_alert_warning(
-        "Would not install CmdStan in a non-interactive session because {.code force = FALSE}."
-      )
-      return(invisible(NULL))
     }
     cli::cli_abort(
       c(
@@ -334,13 +318,7 @@ setup_cmdstanr <- function(
     )
   }
 
-  if (is_interactive_session() && !force) {
-    if (dry_run) {
-      cli::cli_alert_info(
-        "Would ask before installing/upgrading CmdStan."
-      )
-      return(invisible(NULL))
-    }
+  if (!dry_run && is_interactive_session() && !force) {
     title <- if (needs_install) {
       "Download and compile CmdStan now?"
     } else {
@@ -356,7 +334,7 @@ setup_cmdstanr <- function(
   }
 
   run_side_effect(
-    "install CmdStan",
+    "install or upgrade CmdStan",
     {
       cli::cli_process_start("Installing CmdStan (this can take some time)...")
       cmdstanr::install_cmdstan(quiet = quiet, overwrite = TRUE, cores = cores)

--- a/R/update.R
+++ b/R/update.R
@@ -134,7 +134,7 @@ stanflow_deps <- function(
 #'
 #' @description
 #' Checks for outdated Stan workflow packages and installs updates. This function
-#' requires an interactive R session and will error otherwise.
+#' requires an interactive R session for installation unless `dry_run = TRUE`.
 #' Adapted from [tidyverse::tidyverse_update()].
 #'
 #' @return Invisibly returns a data frame of outdated packages (same columns as

--- a/R/update.R
+++ b/R/update.R
@@ -189,7 +189,7 @@ stanflow_update <- function(recursive = FALSE, dev = FALSE, dry_run = FALSE) {
   )
   cli::cat_line()
 
-  if (is_interactive_session()) {
+  if (!dry_run && is_interactive_session()) {
     title <- if (dev) {
       "Update packages from Stan Universe (Dev)?"
     } else {
@@ -238,10 +238,10 @@ stanflow_update <- function(recursive = FALSE, dev = FALSE, dry_run = FALSE) {
         }
       )
     },
-    code = paste0(
-      "utils::install.packages(",
-      dry_code_package_vector(behind$package),
-      ", repos = stanflow::stan_repos(dev), quiet = TRUE)"
+    code = sprintf(
+      "utils::install.packages(%s, repos = stanflow::stan_repos(%s), quiet = TRUE)",
+      deparse1(behind$package),
+      deparse1(dev)
     )
   )
 

--- a/R/update.R
+++ b/R/update.R
@@ -189,7 +189,7 @@ stanflow_update <- function(
     )
   }
 
-  deps <- stanflow_deps(recursive, dev = dev, check_updates = TRUE)
+  deps <- stanflow_deps(recursive, dev = dev, check_updates = check_updates)
   behind <- deps[deps$behind, ]
 
   if (nrow(behind) == 0) {

--- a/R/update.R
+++ b/R/update.R
@@ -135,9 +135,8 @@ stanflow_deps <- function(
 #' @description
 #' Checks for outdated Stan workflow packages and installs updates. This function
 #' requires an interactive R session for installation unless `dry_run = TRUE`.
-#' By default, dry runs do not query package repositories. Use
-#' `dry_run = TRUE, check_updates = TRUE` to list exact outdated packages without
-#' installing.
+#' Dry runs check repositories and preview installs without prompting or
+#' installing packages.
 #' Adapted from [tidyverse::tidyverse_update()].
 #'
 #' @return Invisibly returns a data frame of outdated packages (same columns as
@@ -154,30 +153,14 @@ stanflow_deps <- function(
 #'
 #' @inheritParams stanflow_deps
 #' @param dry_run Logical. If `TRUE`, previews update steps without installing
-#'   packages or prompting. By default, this also skips repository checks.
-#' @param check_updates Logical. Defaults to `FALSE` for dry runs and `TRUE`
-#'   otherwise. With `dry_run = TRUE`, set `check_updates = TRUE` to query package
-#'   repositories and list exact outdated packages without installing.
+#'   packages or prompting.
 #' @export
 stanflow_update <- function(
   recursive = FALSE,
   dev = FALSE,
-  dry_run = FALSE,
-  check_updates = !dry_run
+  dry_run = FALSE
 ) {
   run_side_effect <- dry_runner(dry_run)
-
-  if (dry_run && !check_updates) {
-    repo_label <- if (dev) "Stan Universe (Dev)" else "R-multiverse (Stable)"
-    scope <- if (recursive) "full dependency tree" else "direct dependencies"
-    cli::cli_alert_info(
-      "Would check {scope} for available updates from {repo_label}."
-    )
-    cli::cli_alert_info(
-      "Would prompt before installing any outdated packages."
-    )
-    return(invisible(NULL))
-  }
 
   if (!dry_run && !is_interactive_session()) {
     cli::cli_abort(
@@ -189,7 +172,7 @@ stanflow_update <- function(
     )
   }
 
-  deps <- stanflow_deps(recursive, dev = dev, check_updates = check_updates)
+  deps <- stanflow_deps(recursive, dev = dev, check_updates = TRUE)
   behind <- deps[deps$behind, ]
 
   if (nrow(behind) == 0) {

--- a/R/update.R
+++ b/R/update.R
@@ -135,6 +135,9 @@ stanflow_deps <- function(
 #' @description
 #' Checks for outdated Stan workflow packages and installs updates. This function
 #' requires an interactive R session for installation unless `dry_run = TRUE`.
+#' By default, dry runs do not query package repositories. Use
+#' `dry_run = TRUE, check_updates = TRUE` to list exact outdated packages without
+#' installing.
 #' Adapted from [tidyverse::tidyverse_update()].
 #'
 #' @return Invisibly returns a data frame of outdated packages (same columns as
@@ -150,10 +153,31 @@ stanflow_deps <- function(
 #' }
 #'
 #' @inheritParams stanflow_deps
-#' @inheritParams setup_interface
+#' @param dry_run Logical. If `TRUE`, previews update steps without installing
+#'   packages or prompting. By default, this also skips repository checks.
+#' @param check_updates Logical. Defaults to `FALSE` for dry runs and `TRUE`
+#'   otherwise. With `dry_run = TRUE`, set `check_updates = TRUE` to query package
+#'   repositories and list exact outdated packages without installing.
 #' @export
-stanflow_update <- function(recursive = FALSE, dev = FALSE, dry_run = FALSE) {
+stanflow_update <- function(
+  recursive = FALSE,
+  dev = FALSE,
+  dry_run = FALSE,
+  check_updates = !dry_run
+) {
   run_side_effect <- dry_runner(dry_run)
+
+  if (dry_run && !check_updates) {
+    repo_label <- if (dev) "Stan Universe (Dev)" else "R-multiverse (Stable)"
+    scope <- if (recursive) "full dependency tree" else "direct dependencies"
+    cli::cli_alert_info(
+      "Would check {scope} for available updates from {repo_label}."
+    )
+    cli::cli_alert_info(
+      "Would prompt before installing any outdated packages."
+    )
+    return(invisible(NULL))
+  }
 
   if (!dry_run && !is_interactive_session()) {
     cli::cli_abort(

--- a/R/update.R
+++ b/R/update.R
@@ -150,9 +150,12 @@ stanflow_deps <- function(
 #' }
 #'
 #' @inheritParams stanflow_deps
+#' @inheritParams setup_interface
 #' @export
-stanflow_update <- function(recursive = FALSE, dev = FALSE) {
-  if (!is_interactive_session()) {
+stanflow_update <- function(recursive = FALSE, dev = FALSE, dry_run = FALSE) {
+  run_side_effect <- dry_runner(dry_run)
+
+  if (!dry_run && !is_interactive_session()) {
     cli::cli_abort(
       c(
         "{.fn stanflow_update} must be run interactively.",
@@ -206,25 +209,40 @@ stanflow_update <- function(recursive = FALSE, dev = FALSE) {
   }
 
   # Muffle all warnings except cannot install
-  withCallingHandlers(
-    utils::install.packages(behind$package, repos = repos, quiet = TRUE),
-    warning = function(w) {
-      if (
-        grepl(
-          "cannot remove prior installation of package",
-          w$message,
-          fixed = TRUE
-        )
-      ) {
-        m <- regexpr("[\u2018'](.+?)[\u2019']", w$message)
-        if (m != -1) {
-          pkg <- substring(w$message, m + 1, m + attr(m, "match.length") - 2)
-          pkgs_to_report <<- c(pkgs_to_report, pkg)
+  package_list <- paste0("{.pkg ", behind$package, "}", collapse = ", ")
+  run_side_effect(
+    "install {package_list}",
+    {
+      withCallingHandlers(
+        utils::install.packages(behind$package, repos = repos, quiet = TRUE),
+        warning = function(w) {
+          if (
+            grepl(
+              "cannot remove prior installation of package",
+              w$message,
+              fixed = TRUE
+            )
+          ) {
+            m <- regexpr("[\u2018'](.+?)[\u2019']", w$message)
+            if (m != -1) {
+              pkg <- substring(
+                w$message,
+                m + 1,
+                m + attr(m, "match.length") - 2
+              )
+              pkgs_to_report <<- c(pkgs_to_report, pkg)
+            }
+          } else {
+            invokeRestart("muffleWarning")
+          }
         }
-      } else {
-        invokeRestart("muffleWarning")
-      }
-    }
+      )
+    },
+    code = paste0(
+      "utils::install.packages(",
+      dry_code_package_vector(behind$package),
+      ", repos = stanflow::stan_repos(dev), quiet = TRUE)"
+    )
   )
 
   if (length(pkgs_to_report)) {

--- a/man/setup_brms.Rd
+++ b/man/setup_brms.Rd
@@ -4,7 +4,7 @@
 \alias{setup_brms}
 \title{Setup brms}
 \usage{
-setup_brms(quiet, brms_backend, cores)
+setup_brms(quiet, brms_backend, cores, dry_run = FALSE)
 }
 \arguments{
 \item{quiet}{Logical. If \code{TRUE}, suppresses status messages. This cannot suppress cmdstan messages.}
@@ -16,6 +16,10 @@ setup_brms(quiet, brms_backend, cores)
 \item{cores}{Integer. Number of cores to use. Defaults to
 \code{getOption("mc.cores")}. You must set \code{options(mc.cores = ...)} or pass
 \code{cores} explicitly.}
+
+\item{dry_run}{Logical. If \code{TRUE}, prints the setup actions that would run
+without installing packages, attaching packages, changing options, fixing
+the toolchain, or installing CmdStan. Defaults to \code{FALSE}.}
 }
 \value{
 Returns \code{NULL} invisibly.

--- a/man/setup_brms.Rd
+++ b/man/setup_brms.Rd
@@ -17,7 +17,9 @@ setup_brms(quiet, brms_backend, cores, dry_run = FALSE)
 \code{getOption("mc.cores")}. You must set \code{options(mc.cores = ...)} or pass
 \code{cores} explicitly.}
 
-\item{dry_run}{Logical. If \code{TRUE}, prints commands without executing them. Dry-run output is shown even when \code{quiet = TRUE}.}
+\item{dry_run}{Logical. If \code{TRUE}, previews mutating setup actions without
+installing, attaching, changing options, or prompting. Dry-run output is
+shown even when \code{quiet = TRUE}.}
 }
 \value{
 Returns \code{NULL} invisibly.

--- a/man/setup_brms.Rd
+++ b/man/setup_brms.Rd
@@ -17,9 +17,7 @@ setup_brms(quiet, brms_backend, cores, dry_run = FALSE)
 \code{getOption("mc.cores")}. You must set \code{options(mc.cores = ...)} or pass
 \code{cores} explicitly.}
 
-\item{dry_run}{Logical. If \code{TRUE}, prints the setup actions that would run
-without installing packages, attaching packages, changing options, fixing
-the toolchain, or installing CmdStan. Defaults to \code{FALSE}.}
+\item{dry_run}{Logical. If \code{TRUE}, prints commands without executing them.}
 }
 \value{
 Returns \code{NULL} invisibly.

--- a/man/setup_brms.Rd
+++ b/man/setup_brms.Rd
@@ -17,7 +17,7 @@ setup_brms(quiet, brms_backend, cores, dry_run = FALSE)
 \code{getOption("mc.cores")}. You must set \code{options(mc.cores = ...)} or pass
 \code{cores} explicitly.}
 
-\item{dry_run}{Logical. If \code{TRUE}, prints commands without executing them.}
+\item{dry_run}{Logical. If \code{TRUE}, prints commands without executing them. Dry-run output is shown even when \code{quiet = TRUE}.}
 }
 \value{
 Returns \code{NULL} invisibly.

--- a/man/setup_cmdstanr.Rd
+++ b/man/setup_cmdstanr.Rd
@@ -4,7 +4,14 @@
 \alias{setup_cmdstanr}
 \title{Setup cmdstanr and CmdStan}
 \usage{
-setup_cmdstanr(quiet, force, reinstall = FALSE, check_updates = TRUE, cores)
+setup_cmdstanr(
+  quiet,
+  force,
+  reinstall = FALSE,
+  check_updates = TRUE,
+  cores,
+  dry_run = FALSE
+)
 }
 \arguments{
 \item{quiet}{Logical. If \code{TRUE}, suppresses status messages. This cannot suppress cmdstan messages.}
@@ -18,6 +25,10 @@ setup_cmdstanr(quiet, force, reinstall = FALSE, check_updates = TRUE, cores)
 \item{cores}{Integer. Number of cores to use. Defaults to
 \code{getOption("mc.cores")}. You must set \code{options(mc.cores = ...)} or pass
 \code{cores} explicitly.}
+
+\item{dry_run}{Logical. If \code{TRUE}, prints the setup actions that would run
+without installing packages, attaching packages, changing options, fixing
+the toolchain, or installing CmdStan. Defaults to \code{FALSE}.}
 }
 \value{
 Returns \code{TRUE} invisibly when no install/upgrade is needed.

--- a/man/setup_cmdstanr.Rd
+++ b/man/setup_cmdstanr.Rd
@@ -26,7 +26,9 @@ setup_cmdstanr(
 \code{getOption("mc.cores")}. You must set \code{options(mc.cores = ...)} or pass
 \code{cores} explicitly.}
 
-\item{dry_run}{Logical. If \code{TRUE}, prints commands without executing them. Dry-run output is shown even when \code{quiet = TRUE}.}
+\item{dry_run}{Logical. If \code{TRUE}, previews mutating setup actions without
+installing, attaching, changing options, or prompting. Dry-run output is
+shown even when \code{quiet = TRUE}.}
 }
 \value{
 Returns \code{TRUE} invisibly when no install/upgrade is needed.

--- a/man/setup_cmdstanr.Rd
+++ b/man/setup_cmdstanr.Rd
@@ -26,7 +26,7 @@ setup_cmdstanr(
 \code{getOption("mc.cores")}. You must set \code{options(mc.cores = ...)} or pass
 \code{cores} explicitly.}
 
-\item{dry_run}{Logical. If \code{TRUE}, prints commands without executing them.}
+\item{dry_run}{Logical. If \code{TRUE}, prints commands without executing them. Dry-run output is shown even when \code{quiet = TRUE}.}
 }
 \value{
 Returns \code{TRUE} invisibly when no install/upgrade is needed.

--- a/man/setup_cmdstanr.Rd
+++ b/man/setup_cmdstanr.Rd
@@ -26,9 +26,7 @@ setup_cmdstanr(
 \code{getOption("mc.cores")}. You must set \code{options(mc.cores = ...)} or pass
 \code{cores} explicitly.}
 
-\item{dry_run}{Logical. If \code{TRUE}, prints the setup actions that would run
-without installing packages, attaching packages, changing options, fixing
-the toolchain, or installing CmdStan. Defaults to \code{FALSE}.}
+\item{dry_run}{Logical. If \code{TRUE}, prints commands without executing them.}
 }
 \value{
 Returns \code{TRUE} invisibly when no install/upgrade is needed.

--- a/man/setup_interface.Rd
+++ b/man/setup_interface.Rd
@@ -41,9 +41,7 @@ R-multiverse or CRAN. If \code{TRUE}, installs development versions from Stan R-
 
 \item{rstan_auto_write}{Logical. If \code{TRUE} (default), sets \code{rstan::rstan_options(auto_write = TRUE)}}
 
-\item{dry_run}{Logical. If \code{TRUE}, prints the setup actions that would run
-without installing packages, attaching packages, changing options, fixing
-the toolchain, or installing CmdStan. Defaults to \code{FALSE}.}
+\item{dry_run}{Logical. If \code{TRUE}, prints commands without executing them.}
 }
 \value{
 Returns attached package names invisibly.

--- a/man/setup_interface.Rd
+++ b/man/setup_interface.Rd
@@ -13,7 +13,8 @@ setup_interface(
   check_updates = FALSE,
   dev = FALSE,
   brms_backend = c("cmdstanr", "rstan"),
-  rstan_auto_write = TRUE
+  rstan_auto_write = TRUE,
+  dry_run = FALSE
 )
 }
 \arguments{
@@ -39,6 +40,10 @@ R-multiverse or CRAN. If \code{TRUE}, installs development versions from Stan R-
 \code{c("cmdstanr", "rstan")}.}
 
 \item{rstan_auto_write}{Logical. If \code{TRUE} (default), sets \code{rstan::rstan_options(auto_write = TRUE)}}
+
+\item{dry_run}{Logical. If \code{TRUE}, prints the setup actions that would run
+without installing packages, attaching packages, changing options, fixing
+the toolchain, or installing CmdStan. Defaults to \code{FALSE}.}
 }
 \value{
 Returns attached package names invisibly.

--- a/man/setup_interface.Rd
+++ b/man/setup_interface.Rd
@@ -41,10 +41,12 @@ R-multiverse or CRAN. If \code{TRUE}, installs development versions from Stan R-
 
 \item{rstan_auto_write}{Logical. If \code{TRUE} (default), sets \code{rstan::rstan_options(auto_write = TRUE)}}
 
-\item{dry_run}{Logical. If \code{TRUE}, prints commands without executing them. Dry-run output is shown even when \code{quiet = TRUE}.}
+\item{dry_run}{Logical. If \code{TRUE}, previews mutating setup actions without
+installing, attaching, changing options, or prompting. Dry-run output is
+shown even when \code{quiet = TRUE}.}
 }
 \value{
-Returns attached package names invisibly.
+Returns attached package names invisibly. With \code{dry_run = TRUE}, returns the package names that would be attached.
 }
 \description{
 This function ensures specific Stan interfaces are installed, configured,

--- a/man/setup_interface.Rd
+++ b/man/setup_interface.Rd
@@ -41,7 +41,7 @@ R-multiverse or CRAN. If \code{TRUE}, installs development versions from Stan R-
 
 \item{rstan_auto_write}{Logical. If \code{TRUE} (default), sets \code{rstan::rstan_options(auto_write = TRUE)}}
 
-\item{dry_run}{Logical. If \code{TRUE}, prints commands without executing them.}
+\item{dry_run}{Logical. If \code{TRUE}, prints commands without executing them. Dry-run output is shown even when \code{quiet = TRUE}.}
 }
 \value{
 Returns attached package names invisibly.

--- a/man/setup_rstan.Rd
+++ b/man/setup_rstan.Rd
@@ -15,9 +15,7 @@ setup_rstan(quiet, cores, rstan_auto_write, dry_run = FALSE)
 
 \item{rstan_auto_write}{Logical. If \code{TRUE} (default), sets \code{rstan::rstan_options(auto_write = TRUE)}}
 
-\item{dry_run}{Logical. If \code{TRUE}, prints the setup actions that would run
-without installing packages, attaching packages, changing options, fixing
-the toolchain, or installing CmdStan. Defaults to \code{FALSE}.}
+\item{dry_run}{Logical. If \code{TRUE}, prints commands without executing them.}
 }
 \value{
 Returns \code{NULL} invisibly.

--- a/man/setup_rstan.Rd
+++ b/man/setup_rstan.Rd
@@ -15,7 +15,9 @@ setup_rstan(quiet, cores, rstan_auto_write, dry_run = FALSE)
 
 \item{rstan_auto_write}{Logical. If \code{TRUE} (default), sets \code{rstan::rstan_options(auto_write = TRUE)}}
 
-\item{dry_run}{Logical. If \code{TRUE}, prints commands without executing them. Dry-run output is shown even when \code{quiet = TRUE}.}
+\item{dry_run}{Logical. If \code{TRUE}, previews mutating setup actions without
+installing, attaching, changing options, or prompting. Dry-run output is
+shown even when \code{quiet = TRUE}.}
 }
 \value{
 Returns \code{NULL} invisibly.

--- a/man/setup_rstan.Rd
+++ b/man/setup_rstan.Rd
@@ -15,7 +15,7 @@ setup_rstan(quiet, cores, rstan_auto_write, dry_run = FALSE)
 
 \item{rstan_auto_write}{Logical. If \code{TRUE} (default), sets \code{rstan::rstan_options(auto_write = TRUE)}}
 
-\item{dry_run}{Logical. If \code{TRUE}, prints commands without executing them.}
+\item{dry_run}{Logical. If \code{TRUE}, prints commands without executing them. Dry-run output is shown even when \code{quiet = TRUE}.}
 }
 \value{
 Returns \code{NULL} invisibly.

--- a/man/setup_rstan.Rd
+++ b/man/setup_rstan.Rd
@@ -4,7 +4,7 @@
 \alias{setup_rstan}
 \title{Setup rstan}
 \usage{
-setup_rstan(quiet, cores, rstan_auto_write)
+setup_rstan(quiet, cores, rstan_auto_write, dry_run = FALSE)
 }
 \arguments{
 \item{quiet}{Logical. If \code{TRUE}, suppresses status messages. This cannot suppress cmdstan messages.}
@@ -14,6 +14,10 @@ setup_rstan(quiet, cores, rstan_auto_write)
 \code{cores} explicitly.}
 
 \item{rstan_auto_write}{Logical. If \code{TRUE} (default), sets \code{rstan::rstan_options(auto_write = TRUE)}}
+
+\item{dry_run}{Logical. If \code{TRUE}, prints the setup actions that would run
+without installing packages, attaching packages, changing options, fixing
+the toolchain, or installing CmdStan. Defaults to \code{FALSE}.}
 }
 \value{
 Returns \code{NULL} invisibly.

--- a/man/setup_rstanarm.Rd
+++ b/man/setup_rstanarm.Rd
@@ -4,7 +4,7 @@
 \alias{setup_rstanarm}
 \title{Setup rstanarm}
 \usage{
-setup_rstanarm(quiet, cores)
+setup_rstanarm(quiet, cores, dry_run = FALSE)
 }
 \arguments{
 \item{quiet}{Logical. If \code{TRUE}, suppresses status messages. This cannot suppress cmdstan messages.}
@@ -12,6 +12,10 @@ setup_rstanarm(quiet, cores)
 \item{cores}{Integer. Number of cores to use. Defaults to
 \code{getOption("mc.cores")}. You must set \code{options(mc.cores = ...)} or pass
 \code{cores} explicitly.}
+
+\item{dry_run}{Logical. If \code{TRUE}, prints the setup actions that would run
+without installing packages, attaching packages, changing options, fixing
+the toolchain, or installing CmdStan. Defaults to \code{FALSE}.}
 }
 \value{
 Returns \code{NULL} invisibly.

--- a/man/setup_rstanarm.Rd
+++ b/man/setup_rstanarm.Rd
@@ -13,9 +13,7 @@ setup_rstanarm(quiet, cores, dry_run = FALSE)
 \code{getOption("mc.cores")}. You must set \code{options(mc.cores = ...)} or pass
 \code{cores} explicitly.}
 
-\item{dry_run}{Logical. If \code{TRUE}, prints the setup actions that would run
-without installing packages, attaching packages, changing options, fixing
-the toolchain, or installing CmdStan. Defaults to \code{FALSE}.}
+\item{dry_run}{Logical. If \code{TRUE}, prints commands without executing them.}
 }
 \value{
 Returns \code{NULL} invisibly.

--- a/man/setup_rstanarm.Rd
+++ b/man/setup_rstanarm.Rd
@@ -13,7 +13,9 @@ setup_rstanarm(quiet, cores, dry_run = FALSE)
 \code{getOption("mc.cores")}. You must set \code{options(mc.cores = ...)} or pass
 \code{cores} explicitly.}
 
-\item{dry_run}{Logical. If \code{TRUE}, prints commands without executing them. Dry-run output is shown even when \code{quiet = TRUE}.}
+\item{dry_run}{Logical. If \code{TRUE}, previews mutating setup actions without
+installing, attaching, changing options, or prompting. Dry-run output is
+shown even when \code{quiet = TRUE}.}
 }
 \value{
 Returns \code{NULL} invisibly.

--- a/man/setup_rstanarm.Rd
+++ b/man/setup_rstanarm.Rd
@@ -13,7 +13,7 @@ setup_rstanarm(quiet, cores, dry_run = FALSE)
 \code{getOption("mc.cores")}. You must set \code{options(mc.cores = ...)} or pass
 \code{cores} explicitly.}
 
-\item{dry_run}{Logical. If \code{TRUE}, prints commands without executing them.}
+\item{dry_run}{Logical. If \code{TRUE}, prints commands without executing them. Dry-run output is shown even when \code{quiet = TRUE}.}
 }
 \value{
 Returns \code{NULL} invisibly.

--- a/man/stanflow_update.Rd
+++ b/man/stanflow_update.Rd
@@ -16,9 +16,7 @@ recursively.}
 (stable releases). If \code{TRUE}, checks the Stan R-universe (dev versions). This is
 only cogent for Stan packages, and cannot compare two dev versions.}
 
-\item{dry_run}{Logical. If \code{TRUE}, prints the setup actions that would run
-without installing packages, attaching packages, changing options, fixing
-the toolchain, or installing CmdStan. Defaults to \code{FALSE}.}
+\item{dry_run}{Logical. If \code{TRUE}, prints commands without executing them.}
 }
 \value{
 Invisibly returns a data frame of outdated packages (same columns as

--- a/man/stanflow_update.Rd
+++ b/man/stanflow_update.Rd
@@ -25,7 +25,7 @@ needed.
 }
 \description{
 Checks for outdated Stan workflow packages and installs updates. This function
-requires an interactive R session and will error otherwise.
+requires an interactive R session for installation unless \code{dry_run = TRUE}.
 Adapted from \code{\link[tidyverse:tidyverse_update]{tidyverse::tidyverse_update()}}.
 }
 \examples{

--- a/man/stanflow_update.Rd
+++ b/man/stanflow_update.Rd
@@ -4,12 +4,7 @@
 \alias{stanflow_update}
 \title{Update stanflow packages}
 \usage{
-stanflow_update(
-  recursive = FALSE,
-  dev = FALSE,
-  dry_run = FALSE,
-  check_updates = !dry_run
-)
+stanflow_update(recursive = FALSE, dev = FALSE, dry_run = FALSE)
 }
 \arguments{
 \item{recursive}{If \code{TRUE}, will also list dependencies of dependencies. When
@@ -22,11 +17,7 @@ recursively.}
 only cogent for Stan packages, and cannot compare two dev versions.}
 
 \item{dry_run}{Logical. If \code{TRUE}, previews update steps without installing
-packages or prompting. By default, this also skips repository checks.}
-
-\item{check_updates}{Logical. Defaults to \code{FALSE} for dry runs and \code{TRUE}
-otherwise. With \code{dry_run = TRUE}, set \code{check_updates = TRUE} to query package
-repositories and list exact outdated packages without installing.}
+packages or prompting.}
 }
 \value{
 Invisibly returns a data frame of outdated packages (same columns as
@@ -36,9 +27,8 @@ needed.
 \description{
 Checks for outdated Stan workflow packages and installs updates. This function
 requires an interactive R session for installation unless \code{dry_run = TRUE}.
-By default, dry runs do not query package repositories. Use
-\verb{dry_run = TRUE, check_updates = TRUE} to list exact outdated packages without
-installing.
+Dry runs check repositories and preview installs without prompting or
+installing packages.
 Adapted from \code{\link[tidyverse:tidyverse_update]{tidyverse::tidyverse_update()}}.
 }
 \examples{

--- a/man/stanflow_update.Rd
+++ b/man/stanflow_update.Rd
@@ -4,7 +4,7 @@
 \alias{stanflow_update}
 \title{Update stanflow packages}
 \usage{
-stanflow_update(recursive = FALSE, dev = FALSE)
+stanflow_update(recursive = FALSE, dev = FALSE, dry_run = FALSE)
 }
 \arguments{
 \item{recursive}{If \code{TRUE}, will also list dependencies of dependencies. When
@@ -15,6 +15,10 @@ recursively.}
 \item{dev}{If \code{FALSE} (default), checks for updates in the R-multiverse or CRAN
 (stable releases). If \code{TRUE}, checks the Stan R-universe (dev versions). This is
 only cogent for Stan packages, and cannot compare two dev versions.}
+
+\item{dry_run}{Logical. If \code{TRUE}, prints the setup actions that would run
+without installing packages, attaching packages, changing options, fixing
+the toolchain, or installing CmdStan. Defaults to \code{FALSE}.}
 }
 \value{
 Invisibly returns a data frame of outdated packages (same columns as

--- a/man/stanflow_update.Rd
+++ b/man/stanflow_update.Rd
@@ -4,7 +4,12 @@
 \alias{stanflow_update}
 \title{Update stanflow packages}
 \usage{
-stanflow_update(recursive = FALSE, dev = FALSE, dry_run = FALSE)
+stanflow_update(
+  recursive = FALSE,
+  dev = FALSE,
+  dry_run = FALSE,
+  check_updates = !dry_run
+)
 }
 \arguments{
 \item{recursive}{If \code{TRUE}, will also list dependencies of dependencies. When
@@ -16,7 +21,12 @@ recursively.}
 (stable releases). If \code{TRUE}, checks the Stan R-universe (dev versions). This is
 only cogent for Stan packages, and cannot compare two dev versions.}
 
-\item{dry_run}{Logical. If \code{TRUE}, prints commands without executing them. Dry-run output is shown even when \code{quiet = TRUE}.}
+\item{dry_run}{Logical. If \code{TRUE}, previews update steps without installing
+packages or prompting. By default, this also skips repository checks.}
+
+\item{check_updates}{Logical. Defaults to \code{FALSE} for dry runs and \code{TRUE}
+otherwise. With \code{dry_run = TRUE}, set \code{check_updates = TRUE} to query package
+repositories and list exact outdated packages without installing.}
 }
 \value{
 Invisibly returns a data frame of outdated packages (same columns as
@@ -26,6 +36,9 @@ needed.
 \description{
 Checks for outdated Stan workflow packages and installs updates. This function
 requires an interactive R session for installation unless \code{dry_run = TRUE}.
+By default, dry runs do not query package repositories. Use
+\verb{dry_run = TRUE, check_updates = TRUE} to list exact outdated packages without
+installing.
 Adapted from \code{\link[tidyverse:tidyverse_update]{tidyverse::tidyverse_update()}}.
 }
 \examples{

--- a/man/stanflow_update.Rd
+++ b/man/stanflow_update.Rd
@@ -16,7 +16,7 @@ recursively.}
 (stable releases). If \code{TRUE}, checks the Stan R-universe (dev versions). This is
 only cogent for Stan packages, and cannot compare two dev versions.}
 
-\item{dry_run}{Logical. If \code{TRUE}, prints commands without executing them.}
+\item{dry_run}{Logical. If \code{TRUE}, prints commands without executing them. Dry-run output is shown even when \code{quiet = TRUE}.}
 }
 \value{
 Invisibly returns a data frame of outdated packages (same columns as

--- a/tests/testthat/_snaps/interfaces.md
+++ b/tests/testthat/_snaps/interfaces.md
@@ -5,7 +5,7 @@
         quiet = FALSE, dry_run = TRUE)
     Message
       i Would configure brms: set `options(mc.cores = 1)` and `options(brms.backend = 'rstan')`: options(mc.cores = 1); options(brms.backend = "rstan").
-      i Would attach brms: stanflow:::.same_library("brms").
+      i Would attach brms: library("brms").
 
 # setup_interface dry_run output is stable for cmdstanr
 
@@ -14,8 +14,10 @@
         quiet = FALSE, dry_run = TRUE)
     Message
       i Would check and fix the CmdStan toolchain: cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = FALSE).
+      ! CmdStan binaries are missing or force-reinstall requested.
+      i Would install or upgrade CmdStan: cmdstanr::install_cmdstan(quiet = FALSE, overwrite = TRUE, cores = 1).
       i Would configure cmdstanr: set `options(mc.cores = 1)`: options(mc.cores = 1).
-      i Would attach cmdstanr: stanflow:::.same_library("cmdstanr").
+      i Would attach cmdstanr: library("cmdstanr").
 
 # setup_interface dry_run output is stable for rstan
 
@@ -24,7 +26,7 @@
         quiet = FALSE, dry_run = TRUE)
     Message
       i Would configure rstan: set `options(mc.cores = 1)` and `rstan::rstan_options(auto_write = TRUE)`: options(mc.cores = 1); rstan::rstan_options(auto_write = TRUE).
-      i Would attach rstan: stanflow:::.same_library("rstan").
+      i Would attach rstan: library("rstan").
 
 # setup_interface dry_run output is stable for rstanarm
 
@@ -33,7 +35,7 @@
         quiet = FALSE, dry_run = TRUE)
     Message
       i Would configure rstanarm: set `options(mc.cores = 1)`: options(mc.cores = 1).
-      i Would attach rstanarm: stanflow:::.same_library("rstanarm").
+      i Would attach rstanarm: library("rstanarm").
 
 # setup_interface dry_run output is stable for brms, cmdstanr
 
@@ -42,10 +44,12 @@
         quiet = FALSE, dry_run = TRUE)
     Message
       i Would configure brms: set `options(mc.cores = 1)` and `options(brms.backend = 'rstan')`: options(mc.cores = 1); options(brms.backend = "rstan").
-      i Would attach brms: stanflow:::.same_library("brms").
+      i Would attach brms: library("brms").
       i Would check and fix the CmdStan toolchain: cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = FALSE).
+      ! CmdStan binaries are missing or force-reinstall requested.
+      i Would install or upgrade CmdStan: cmdstanr::install_cmdstan(quiet = FALSE, overwrite = TRUE, cores = 1).
       i Would configure cmdstanr: set `options(mc.cores = 1)`: options(mc.cores = 1).
-      i Would attach cmdstanr: stanflow:::.same_library("cmdstanr").
+      i Would attach cmdstanr: library("cmdstanr").
 
 # setup_interface dry_run output is stable for brms, rstan
 
@@ -54,9 +58,9 @@
         quiet = FALSE, dry_run = TRUE)
     Message
       i Would configure brms: set `options(mc.cores = 1)` and `options(brms.backend = 'rstan')`: options(mc.cores = 1); options(brms.backend = "rstan").
-      i Would attach brms: stanflow:::.same_library("brms").
+      i Would attach brms: library("brms").
       i Would configure rstan: set `options(mc.cores = 1)` and `rstan::rstan_options(auto_write = TRUE)`: options(mc.cores = 1); rstan::rstan_options(auto_write = TRUE).
-      i Would attach rstan: stanflow:::.same_library("rstan").
+      i Would attach rstan: library("rstan").
 
 # setup_interface dry_run output is stable for brms, rstanarm
 
@@ -65,9 +69,9 @@
         quiet = FALSE, dry_run = TRUE)
     Message
       i Would configure brms: set `options(mc.cores = 1)` and `options(brms.backend = 'rstan')`: options(mc.cores = 1); options(brms.backend = "rstan").
-      i Would attach brms: stanflow:::.same_library("brms").
+      i Would attach brms: library("brms").
       i Would configure rstanarm: set `options(mc.cores = 1)`: options(mc.cores = 1).
-      i Would attach rstanarm: stanflow:::.same_library("rstanarm").
+      i Would attach rstanarm: library("rstanarm").
 
 # setup_interface dry_run output is stable for cmdstanr, rstan
 
@@ -76,10 +80,12 @@
         quiet = FALSE, dry_run = TRUE)
     Message
       i Would check and fix the CmdStan toolchain: cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = FALSE).
+      ! CmdStan binaries are missing or force-reinstall requested.
+      i Would install or upgrade CmdStan: cmdstanr::install_cmdstan(quiet = FALSE, overwrite = TRUE, cores = 1).
       i Would configure cmdstanr: set `options(mc.cores = 1)`: options(mc.cores = 1).
-      i Would attach cmdstanr: stanflow:::.same_library("cmdstanr").
+      i Would attach cmdstanr: library("cmdstanr").
       i Would configure rstan: set `options(mc.cores = 1)` and `rstan::rstan_options(auto_write = TRUE)`: options(mc.cores = 1); rstan::rstan_options(auto_write = TRUE).
-      i Would attach rstan: stanflow:::.same_library("rstan").
+      i Would attach rstan: library("rstan").
 
 # setup_interface dry_run output is stable for cmdstanr, rstanarm
 
@@ -88,10 +94,12 @@
         quiet = FALSE, dry_run = TRUE)
     Message
       i Would check and fix the CmdStan toolchain: cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = FALSE).
+      ! CmdStan binaries are missing or force-reinstall requested.
+      i Would install or upgrade CmdStan: cmdstanr::install_cmdstan(quiet = FALSE, overwrite = TRUE, cores = 1).
       i Would configure cmdstanr: set `options(mc.cores = 1)`: options(mc.cores = 1).
-      i Would attach cmdstanr: stanflow:::.same_library("cmdstanr").
+      i Would attach cmdstanr: library("cmdstanr").
       i Would configure rstanarm: set `options(mc.cores = 1)`: options(mc.cores = 1).
-      i Would attach rstanarm: stanflow:::.same_library("rstanarm").
+      i Would attach rstanarm: library("rstanarm").
 
 # setup_interface dry_run output is stable for rstan, rstanarm
 
@@ -100,9 +108,9 @@
         quiet = FALSE, dry_run = TRUE)
     Message
       i Would configure rstan: set `options(mc.cores = 1)` and `rstan::rstan_options(auto_write = TRUE)`: options(mc.cores = 1); rstan::rstan_options(auto_write = TRUE).
-      i Would attach rstan: stanflow:::.same_library("rstan").
+      i Would attach rstan: library("rstan").
       i Would configure rstanarm: set `options(mc.cores = 1)`: options(mc.cores = 1).
-      i Would attach rstanarm: stanflow:::.same_library("rstanarm").
+      i Would attach rstanarm: library("rstanarm").
 
 # setup_interface dry_run output is stable for brms, cmdstanr, rstan
 
@@ -111,12 +119,14 @@
         quiet = FALSE, dry_run = TRUE)
     Message
       i Would configure brms: set `options(mc.cores = 1)` and `options(brms.backend = 'rstan')`: options(mc.cores = 1); options(brms.backend = "rstan").
-      i Would attach brms: stanflow:::.same_library("brms").
+      i Would attach brms: library("brms").
       i Would check and fix the CmdStan toolchain: cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = FALSE).
+      ! CmdStan binaries are missing or force-reinstall requested.
+      i Would install or upgrade CmdStan: cmdstanr::install_cmdstan(quiet = FALSE, overwrite = TRUE, cores = 1).
       i Would configure cmdstanr: set `options(mc.cores = 1)`: options(mc.cores = 1).
-      i Would attach cmdstanr: stanflow:::.same_library("cmdstanr").
+      i Would attach cmdstanr: library("cmdstanr").
       i Would configure rstan: set `options(mc.cores = 1)` and `rstan::rstan_options(auto_write = TRUE)`: options(mc.cores = 1); rstan::rstan_options(auto_write = TRUE).
-      i Would attach rstan: stanflow:::.same_library("rstan").
+      i Would attach rstan: library("rstan").
 
 # setup_interface dry_run output is stable for brms, cmdstanr, rstanarm
 
@@ -125,12 +135,14 @@
         quiet = FALSE, dry_run = TRUE)
     Message
       i Would configure brms: set `options(mc.cores = 1)` and `options(brms.backend = 'rstan')`: options(mc.cores = 1); options(brms.backend = "rstan").
-      i Would attach brms: stanflow:::.same_library("brms").
+      i Would attach brms: library("brms").
       i Would check and fix the CmdStan toolchain: cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = FALSE).
+      ! CmdStan binaries are missing or force-reinstall requested.
+      i Would install or upgrade CmdStan: cmdstanr::install_cmdstan(quiet = FALSE, overwrite = TRUE, cores = 1).
       i Would configure cmdstanr: set `options(mc.cores = 1)`: options(mc.cores = 1).
-      i Would attach cmdstanr: stanflow:::.same_library("cmdstanr").
+      i Would attach cmdstanr: library("cmdstanr").
       i Would configure rstanarm: set `options(mc.cores = 1)`: options(mc.cores = 1).
-      i Would attach rstanarm: stanflow:::.same_library("rstanarm").
+      i Would attach rstanarm: library("rstanarm").
 
 # setup_interface dry_run output is stable for brms, rstan, rstanarm
 
@@ -139,11 +151,11 @@
         quiet = FALSE, dry_run = TRUE)
     Message
       i Would configure brms: set `options(mc.cores = 1)` and `options(brms.backend = 'rstan')`: options(mc.cores = 1); options(brms.backend = "rstan").
-      i Would attach brms: stanflow:::.same_library("brms").
+      i Would attach brms: library("brms").
       i Would configure rstan: set `options(mc.cores = 1)` and `rstan::rstan_options(auto_write = TRUE)`: options(mc.cores = 1); rstan::rstan_options(auto_write = TRUE).
-      i Would attach rstan: stanflow:::.same_library("rstan").
+      i Would attach rstan: library("rstan").
       i Would configure rstanarm: set `options(mc.cores = 1)`: options(mc.cores = 1).
-      i Would attach rstanarm: stanflow:::.same_library("rstanarm").
+      i Would attach rstanarm: library("rstanarm").
 
 # setup_interface dry_run output is stable for cmdstanr, rstan, rstanarm
 
@@ -152,12 +164,14 @@
         quiet = FALSE, dry_run = TRUE)
     Message
       i Would check and fix the CmdStan toolchain: cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = FALSE).
+      ! CmdStan binaries are missing or force-reinstall requested.
+      i Would install or upgrade CmdStan: cmdstanr::install_cmdstan(quiet = FALSE, overwrite = TRUE, cores = 1).
       i Would configure cmdstanr: set `options(mc.cores = 1)`: options(mc.cores = 1).
-      i Would attach cmdstanr: stanflow:::.same_library("cmdstanr").
+      i Would attach cmdstanr: library("cmdstanr").
       i Would configure rstan: set `options(mc.cores = 1)` and `rstan::rstan_options(auto_write = TRUE)`: options(mc.cores = 1); rstan::rstan_options(auto_write = TRUE).
-      i Would attach rstan: stanflow:::.same_library("rstan").
+      i Would attach rstan: library("rstan").
       i Would configure rstanarm: set `options(mc.cores = 1)`: options(mc.cores = 1).
-      i Would attach rstanarm: stanflow:::.same_library("rstanarm").
+      i Would attach rstanarm: library("rstanarm").
 
 # setup_interface dry_run output is stable for brms, cmdstanr, rstan, rstanarm
 
@@ -166,14 +180,16 @@
         quiet = FALSE, dry_run = TRUE)
     Message
       i Would configure brms: set `options(mc.cores = 1)` and `options(brms.backend = 'rstan')`: options(mc.cores = 1); options(brms.backend = "rstan").
-      i Would attach brms: stanflow:::.same_library("brms").
+      i Would attach brms: library("brms").
       i Would check and fix the CmdStan toolchain: cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = FALSE).
+      ! CmdStan binaries are missing or force-reinstall requested.
+      i Would install or upgrade CmdStan: cmdstanr::install_cmdstan(quiet = FALSE, overwrite = TRUE, cores = 1).
       i Would configure cmdstanr: set `options(mc.cores = 1)`: options(mc.cores = 1).
-      i Would attach cmdstanr: stanflow:::.same_library("cmdstanr").
+      i Would attach cmdstanr: library("cmdstanr").
       i Would configure rstan: set `options(mc.cores = 1)` and `rstan::rstan_options(auto_write = TRUE)`: options(mc.cores = 1); rstan::rstan_options(auto_write = TRUE).
-      i Would attach rstan: stanflow:::.same_library("rstan").
+      i Would attach rstan: library("rstan").
       i Would configure rstanarm: set `options(mc.cores = 1)`: options(mc.cores = 1).
-      i Would attach rstanarm: stanflow:::.same_library("rstanarm").
+      i Would attach rstanarm: library("rstanarm").
 
 # setup_interface warns when brms_backend adds cmdstanr
 

--- a/tests/testthat/_snaps/interfaces.md
+++ b/tests/testthat/_snaps/interfaces.md
@@ -14,8 +14,9 @@
         quiet = FALSE, dry_run = TRUE)
     Message
       i Would attach cmdstanr: stanflow:::.same_library("cmdstanr").
-      i Would check and fix the CmdStan toolchain: cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = quiet).
-      i Would configure cmdstanr: set `options(mc.cores = 1)`: options(mc.cores = 1).
+      i Would check and fix the CmdStan toolchain: cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = FALSE).
+      ! CmdStan binaries are missing or force-reinstall requested.
+      ! Would not install CmdStan in a non-interactive session because `force = FALSE`.
 
 # setup_interface dry_run output is stable for rstan
 
@@ -44,8 +45,9 @@
       i Would attach brms: stanflow:::.same_library("brms").
       i Would configure brms: set `options(mc.cores = 1)` and `options(brms.backend = 'rstan')`: options(mc.cores = 1); options(brms.backend = "rstan").
       i Would attach cmdstanr: stanflow:::.same_library("cmdstanr").
-      i Would check and fix the CmdStan toolchain: cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = quiet).
-      i Would configure cmdstanr: set `options(mc.cores = 1)`: options(mc.cores = 1).
+      i Would check and fix the CmdStan toolchain: cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = FALSE).
+      ! CmdStan binaries are missing or force-reinstall requested.
+      ! Would not install CmdStan in a non-interactive session because `force = FALSE`.
 
 # setup_interface dry_run output is stable for brms, rstan
 
@@ -76,8 +78,9 @@
         quiet = FALSE, dry_run = TRUE)
     Message
       i Would attach cmdstanr: stanflow:::.same_library("cmdstanr").
-      i Would check and fix the CmdStan toolchain: cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = quiet).
-      i Would configure cmdstanr: set `options(mc.cores = 1)`: options(mc.cores = 1).
+      i Would check and fix the CmdStan toolchain: cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = FALSE).
+      ! CmdStan binaries are missing or force-reinstall requested.
+      ! Would not install CmdStan in a non-interactive session because `force = FALSE`.
       i Would attach rstan: stanflow:::.same_library("rstan").
       i Would configure rstan: set `options(mc.cores = 1)` and `rstan::rstan_options(auto_write = TRUE)`: options(mc.cores = 1); rstan::rstan_options(auto_write = TRUE).
 
@@ -88,8 +91,9 @@
         quiet = FALSE, dry_run = TRUE)
     Message
       i Would attach cmdstanr: stanflow:::.same_library("cmdstanr").
-      i Would check and fix the CmdStan toolchain: cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = quiet).
-      i Would configure cmdstanr: set `options(mc.cores = 1)`: options(mc.cores = 1).
+      i Would check and fix the CmdStan toolchain: cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = FALSE).
+      ! CmdStan binaries are missing or force-reinstall requested.
+      ! Would not install CmdStan in a non-interactive session because `force = FALSE`.
       i Would attach rstanarm: stanflow:::.same_library("rstanarm").
       i Would configure rstanarm: set `options(mc.cores = 1)`: options(mc.cores = 1).
 
@@ -113,8 +117,9 @@
       i Would attach brms: stanflow:::.same_library("brms").
       i Would configure brms: set `options(mc.cores = 1)` and `options(brms.backend = 'rstan')`: options(mc.cores = 1); options(brms.backend = "rstan").
       i Would attach cmdstanr: stanflow:::.same_library("cmdstanr").
-      i Would check and fix the CmdStan toolchain: cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = quiet).
-      i Would configure cmdstanr: set `options(mc.cores = 1)`: options(mc.cores = 1).
+      i Would check and fix the CmdStan toolchain: cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = FALSE).
+      ! CmdStan binaries are missing or force-reinstall requested.
+      ! Would not install CmdStan in a non-interactive session because `force = FALSE`.
       i Would attach rstan: stanflow:::.same_library("rstan").
       i Would configure rstan: set `options(mc.cores = 1)` and `rstan::rstan_options(auto_write = TRUE)`: options(mc.cores = 1); rstan::rstan_options(auto_write = TRUE).
 
@@ -127,8 +132,9 @@
       i Would attach brms: stanflow:::.same_library("brms").
       i Would configure brms: set `options(mc.cores = 1)` and `options(brms.backend = 'rstan')`: options(mc.cores = 1); options(brms.backend = "rstan").
       i Would attach cmdstanr: stanflow:::.same_library("cmdstanr").
-      i Would check and fix the CmdStan toolchain: cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = quiet).
-      i Would configure cmdstanr: set `options(mc.cores = 1)`: options(mc.cores = 1).
+      i Would check and fix the CmdStan toolchain: cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = FALSE).
+      ! CmdStan binaries are missing or force-reinstall requested.
+      ! Would not install CmdStan in a non-interactive session because `force = FALSE`.
       i Would attach rstanarm: stanflow:::.same_library("rstanarm").
       i Would configure rstanarm: set `options(mc.cores = 1)`: options(mc.cores = 1).
 
@@ -152,8 +158,9 @@
         quiet = FALSE, dry_run = TRUE)
     Message
       i Would attach cmdstanr: stanflow:::.same_library("cmdstanr").
-      i Would check and fix the CmdStan toolchain: cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = quiet).
-      i Would configure cmdstanr: set `options(mc.cores = 1)`: options(mc.cores = 1).
+      i Would check and fix the CmdStan toolchain: cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = FALSE).
+      ! CmdStan binaries are missing or force-reinstall requested.
+      ! Would not install CmdStan in a non-interactive session because `force = FALSE`.
       i Would attach rstan: stanflow:::.same_library("rstan").
       i Would configure rstan: set `options(mc.cores = 1)` and `rstan::rstan_options(auto_write = TRUE)`: options(mc.cores = 1); rstan::rstan_options(auto_write = TRUE).
       i Would attach rstanarm: stanflow:::.same_library("rstanarm").
@@ -168,8 +175,9 @@
       i Would attach brms: stanflow:::.same_library("brms").
       i Would configure brms: set `options(mc.cores = 1)` and `options(brms.backend = 'rstan')`: options(mc.cores = 1); options(brms.backend = "rstan").
       i Would attach cmdstanr: stanflow:::.same_library("cmdstanr").
-      i Would check and fix the CmdStan toolchain: cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = quiet).
-      i Would configure cmdstanr: set `options(mc.cores = 1)`: options(mc.cores = 1).
+      i Would check and fix the CmdStan toolchain: cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = FALSE).
+      ! CmdStan binaries are missing or force-reinstall requested.
+      ! Would not install CmdStan in a non-interactive session because `force = FALSE`.
       i Would attach rstan: stanflow:::.same_library("rstan").
       i Would configure rstan: set `options(mc.cores = 1)` and `rstan::rstan_options(auto_write = TRUE)`: options(mc.cores = 1); rstan::rstan_options(auto_write = TRUE).
       i Would attach rstanarm: stanflow:::.same_library("rstanarm").

--- a/tests/testthat/_snaps/interfaces.md
+++ b/tests/testthat/_snaps/interfaces.md
@@ -5,7 +5,7 @@
         quiet = FALSE, dry_run = TRUE)
     Message
       i Would configure brms: set `options(mc.cores = 1)` and `options(brms.backend = 'rstan')`: options(mc.cores = 1); options(brms.backend = "rstan").
-      i Would attach brms: library("brms").
+      i Would attach brms: library("brms", lib.loc = if ("brms" %in% loadedNamespaces()) dirname(getNamespaceInfo("brms", "path")), character.only = TRUE, warn.conflicts = FALSE).
 
 # setup_interface dry_run output is stable for cmdstanr
 
@@ -17,7 +17,7 @@
       ! CmdStan binaries are missing or force-reinstall requested.
       i Would install or upgrade CmdStan: cmdstanr::install_cmdstan(quiet = FALSE, overwrite = TRUE, cores = 1).
       i Would configure cmdstanr: set `options(mc.cores = 1)`: options(mc.cores = 1).
-      i Would attach cmdstanr: library("cmdstanr").
+      i Would attach cmdstanr: library("cmdstanr", lib.loc = if ("cmdstanr" %in% loadedNamespaces()) dirname(getNamespaceInfo("cmdstanr", "path")), character.only = TRUE, warn.conflicts = FALSE).
 
 # setup_interface dry_run output is stable for rstan
 
@@ -26,7 +26,7 @@
         quiet = FALSE, dry_run = TRUE)
     Message
       i Would configure rstan: set `options(mc.cores = 1)` and `rstan::rstan_options(auto_write = TRUE)`: options(mc.cores = 1); rstan::rstan_options(auto_write = TRUE).
-      i Would attach rstan: library("rstan").
+      i Would attach rstan: library("rstan", lib.loc = if ("rstan" %in% loadedNamespaces()) dirname(getNamespaceInfo("rstan", "path")), character.only = TRUE, warn.conflicts = FALSE).
 
 # setup_interface dry_run output is stable for rstanarm
 
@@ -35,7 +35,7 @@
         quiet = FALSE, dry_run = TRUE)
     Message
       i Would configure rstanarm: set `options(mc.cores = 1)`: options(mc.cores = 1).
-      i Would attach rstanarm: library("rstanarm").
+      i Would attach rstanarm: library("rstanarm", lib.loc = if ("rstanarm" %in% loadedNamespaces()) dirname(getNamespaceInfo("rstanarm", "path")), character.only = TRUE, warn.conflicts = FALSE).
 
 # setup_interface dry_run output is stable for brms, cmdstanr
 
@@ -44,12 +44,12 @@
         quiet = FALSE, dry_run = TRUE)
     Message
       i Would configure brms: set `options(mc.cores = 1)` and `options(brms.backend = 'rstan')`: options(mc.cores = 1); options(brms.backend = "rstan").
-      i Would attach brms: library("brms").
+      i Would attach brms: library("brms", lib.loc = if ("brms" %in% loadedNamespaces()) dirname(getNamespaceInfo("brms", "path")), character.only = TRUE, warn.conflicts = FALSE).
       i Would check and fix the CmdStan toolchain: cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = FALSE).
       ! CmdStan binaries are missing or force-reinstall requested.
       i Would install or upgrade CmdStan: cmdstanr::install_cmdstan(quiet = FALSE, overwrite = TRUE, cores = 1).
       i Would configure cmdstanr: set `options(mc.cores = 1)`: options(mc.cores = 1).
-      i Would attach cmdstanr: library("cmdstanr").
+      i Would attach cmdstanr: library("cmdstanr", lib.loc = if ("cmdstanr" %in% loadedNamespaces()) dirname(getNamespaceInfo("cmdstanr", "path")), character.only = TRUE, warn.conflicts = FALSE).
 
 # setup_interface dry_run output is stable for brms, rstan
 
@@ -58,9 +58,9 @@
         quiet = FALSE, dry_run = TRUE)
     Message
       i Would configure brms: set `options(mc.cores = 1)` and `options(brms.backend = 'rstan')`: options(mc.cores = 1); options(brms.backend = "rstan").
-      i Would attach brms: library("brms").
+      i Would attach brms: library("brms", lib.loc = if ("brms" %in% loadedNamespaces()) dirname(getNamespaceInfo("brms", "path")), character.only = TRUE, warn.conflicts = FALSE).
       i Would configure rstan: set `options(mc.cores = 1)` and `rstan::rstan_options(auto_write = TRUE)`: options(mc.cores = 1); rstan::rstan_options(auto_write = TRUE).
-      i Would attach rstan: library("rstan").
+      i Would attach rstan: library("rstan", lib.loc = if ("rstan" %in% loadedNamespaces()) dirname(getNamespaceInfo("rstan", "path")), character.only = TRUE, warn.conflicts = FALSE).
 
 # setup_interface dry_run output is stable for brms, rstanarm
 
@@ -69,9 +69,9 @@
         quiet = FALSE, dry_run = TRUE)
     Message
       i Would configure brms: set `options(mc.cores = 1)` and `options(brms.backend = 'rstan')`: options(mc.cores = 1); options(brms.backend = "rstan").
-      i Would attach brms: library("brms").
+      i Would attach brms: library("brms", lib.loc = if ("brms" %in% loadedNamespaces()) dirname(getNamespaceInfo("brms", "path")), character.only = TRUE, warn.conflicts = FALSE).
       i Would configure rstanarm: set `options(mc.cores = 1)`: options(mc.cores = 1).
-      i Would attach rstanarm: library("rstanarm").
+      i Would attach rstanarm: library("rstanarm", lib.loc = if ("rstanarm" %in% loadedNamespaces()) dirname(getNamespaceInfo("rstanarm", "path")), character.only = TRUE, warn.conflicts = FALSE).
 
 # setup_interface dry_run output is stable for cmdstanr, rstan
 
@@ -83,9 +83,9 @@
       ! CmdStan binaries are missing or force-reinstall requested.
       i Would install or upgrade CmdStan: cmdstanr::install_cmdstan(quiet = FALSE, overwrite = TRUE, cores = 1).
       i Would configure cmdstanr: set `options(mc.cores = 1)`: options(mc.cores = 1).
-      i Would attach cmdstanr: library("cmdstanr").
+      i Would attach cmdstanr: library("cmdstanr", lib.loc = if ("cmdstanr" %in% loadedNamespaces()) dirname(getNamespaceInfo("cmdstanr", "path")), character.only = TRUE, warn.conflicts = FALSE).
       i Would configure rstan: set `options(mc.cores = 1)` and `rstan::rstan_options(auto_write = TRUE)`: options(mc.cores = 1); rstan::rstan_options(auto_write = TRUE).
-      i Would attach rstan: library("rstan").
+      i Would attach rstan: library("rstan", lib.loc = if ("rstan" %in% loadedNamespaces()) dirname(getNamespaceInfo("rstan", "path")), character.only = TRUE, warn.conflicts = FALSE).
 
 # setup_interface dry_run output is stable for cmdstanr, rstanarm
 
@@ -97,9 +97,9 @@
       ! CmdStan binaries are missing or force-reinstall requested.
       i Would install or upgrade CmdStan: cmdstanr::install_cmdstan(quiet = FALSE, overwrite = TRUE, cores = 1).
       i Would configure cmdstanr: set `options(mc.cores = 1)`: options(mc.cores = 1).
-      i Would attach cmdstanr: library("cmdstanr").
+      i Would attach cmdstanr: library("cmdstanr", lib.loc = if ("cmdstanr" %in% loadedNamespaces()) dirname(getNamespaceInfo("cmdstanr", "path")), character.only = TRUE, warn.conflicts = FALSE).
       i Would configure rstanarm: set `options(mc.cores = 1)`: options(mc.cores = 1).
-      i Would attach rstanarm: library("rstanarm").
+      i Would attach rstanarm: library("rstanarm", lib.loc = if ("rstanarm" %in% loadedNamespaces()) dirname(getNamespaceInfo("rstanarm", "path")), character.only = TRUE, warn.conflicts = FALSE).
 
 # setup_interface dry_run output is stable for rstan, rstanarm
 
@@ -108,9 +108,9 @@
         quiet = FALSE, dry_run = TRUE)
     Message
       i Would configure rstan: set `options(mc.cores = 1)` and `rstan::rstan_options(auto_write = TRUE)`: options(mc.cores = 1); rstan::rstan_options(auto_write = TRUE).
-      i Would attach rstan: library("rstan").
+      i Would attach rstan: library("rstan", lib.loc = if ("rstan" %in% loadedNamespaces()) dirname(getNamespaceInfo("rstan", "path")), character.only = TRUE, warn.conflicts = FALSE).
       i Would configure rstanarm: set `options(mc.cores = 1)`: options(mc.cores = 1).
-      i Would attach rstanarm: library("rstanarm").
+      i Would attach rstanarm: library("rstanarm", lib.loc = if ("rstanarm" %in% loadedNamespaces()) dirname(getNamespaceInfo("rstanarm", "path")), character.only = TRUE, warn.conflicts = FALSE).
 
 # setup_interface dry_run output is stable for brms, cmdstanr, rstan
 
@@ -119,14 +119,14 @@
         quiet = FALSE, dry_run = TRUE)
     Message
       i Would configure brms: set `options(mc.cores = 1)` and `options(brms.backend = 'rstan')`: options(mc.cores = 1); options(brms.backend = "rstan").
-      i Would attach brms: library("brms").
+      i Would attach brms: library("brms", lib.loc = if ("brms" %in% loadedNamespaces()) dirname(getNamespaceInfo("brms", "path")), character.only = TRUE, warn.conflicts = FALSE).
       i Would check and fix the CmdStan toolchain: cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = FALSE).
       ! CmdStan binaries are missing or force-reinstall requested.
       i Would install or upgrade CmdStan: cmdstanr::install_cmdstan(quiet = FALSE, overwrite = TRUE, cores = 1).
       i Would configure cmdstanr: set `options(mc.cores = 1)`: options(mc.cores = 1).
-      i Would attach cmdstanr: library("cmdstanr").
+      i Would attach cmdstanr: library("cmdstanr", lib.loc = if ("cmdstanr" %in% loadedNamespaces()) dirname(getNamespaceInfo("cmdstanr", "path")), character.only = TRUE, warn.conflicts = FALSE).
       i Would configure rstan: set `options(mc.cores = 1)` and `rstan::rstan_options(auto_write = TRUE)`: options(mc.cores = 1); rstan::rstan_options(auto_write = TRUE).
-      i Would attach rstan: library("rstan").
+      i Would attach rstan: library("rstan", lib.loc = if ("rstan" %in% loadedNamespaces()) dirname(getNamespaceInfo("rstan", "path")), character.only = TRUE, warn.conflicts = FALSE).
 
 # setup_interface dry_run output is stable for brms, cmdstanr, rstanarm
 
@@ -135,14 +135,14 @@
         quiet = FALSE, dry_run = TRUE)
     Message
       i Would configure brms: set `options(mc.cores = 1)` and `options(brms.backend = 'rstan')`: options(mc.cores = 1); options(brms.backend = "rstan").
-      i Would attach brms: library("brms").
+      i Would attach brms: library("brms", lib.loc = if ("brms" %in% loadedNamespaces()) dirname(getNamespaceInfo("brms", "path")), character.only = TRUE, warn.conflicts = FALSE).
       i Would check and fix the CmdStan toolchain: cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = FALSE).
       ! CmdStan binaries are missing or force-reinstall requested.
       i Would install or upgrade CmdStan: cmdstanr::install_cmdstan(quiet = FALSE, overwrite = TRUE, cores = 1).
       i Would configure cmdstanr: set `options(mc.cores = 1)`: options(mc.cores = 1).
-      i Would attach cmdstanr: library("cmdstanr").
+      i Would attach cmdstanr: library("cmdstanr", lib.loc = if ("cmdstanr" %in% loadedNamespaces()) dirname(getNamespaceInfo("cmdstanr", "path")), character.only = TRUE, warn.conflicts = FALSE).
       i Would configure rstanarm: set `options(mc.cores = 1)`: options(mc.cores = 1).
-      i Would attach rstanarm: library("rstanarm").
+      i Would attach rstanarm: library("rstanarm", lib.loc = if ("rstanarm" %in% loadedNamespaces()) dirname(getNamespaceInfo("rstanarm", "path")), character.only = TRUE, warn.conflicts = FALSE).
 
 # setup_interface dry_run output is stable for brms, rstan, rstanarm
 
@@ -151,11 +151,11 @@
         quiet = FALSE, dry_run = TRUE)
     Message
       i Would configure brms: set `options(mc.cores = 1)` and `options(brms.backend = 'rstan')`: options(mc.cores = 1); options(brms.backend = "rstan").
-      i Would attach brms: library("brms").
+      i Would attach brms: library("brms", lib.loc = if ("brms" %in% loadedNamespaces()) dirname(getNamespaceInfo("brms", "path")), character.only = TRUE, warn.conflicts = FALSE).
       i Would configure rstan: set `options(mc.cores = 1)` and `rstan::rstan_options(auto_write = TRUE)`: options(mc.cores = 1); rstan::rstan_options(auto_write = TRUE).
-      i Would attach rstan: library("rstan").
+      i Would attach rstan: library("rstan", lib.loc = if ("rstan" %in% loadedNamespaces()) dirname(getNamespaceInfo("rstan", "path")), character.only = TRUE, warn.conflicts = FALSE).
       i Would configure rstanarm: set `options(mc.cores = 1)`: options(mc.cores = 1).
-      i Would attach rstanarm: library("rstanarm").
+      i Would attach rstanarm: library("rstanarm", lib.loc = if ("rstanarm" %in% loadedNamespaces()) dirname(getNamespaceInfo("rstanarm", "path")), character.only = TRUE, warn.conflicts = FALSE).
 
 # setup_interface dry_run output is stable for cmdstanr, rstan, rstanarm
 
@@ -167,11 +167,11 @@
       ! CmdStan binaries are missing or force-reinstall requested.
       i Would install or upgrade CmdStan: cmdstanr::install_cmdstan(quiet = FALSE, overwrite = TRUE, cores = 1).
       i Would configure cmdstanr: set `options(mc.cores = 1)`: options(mc.cores = 1).
-      i Would attach cmdstanr: library("cmdstanr").
+      i Would attach cmdstanr: library("cmdstanr", lib.loc = if ("cmdstanr" %in% loadedNamespaces()) dirname(getNamespaceInfo("cmdstanr", "path")), character.only = TRUE, warn.conflicts = FALSE).
       i Would configure rstan: set `options(mc.cores = 1)` and `rstan::rstan_options(auto_write = TRUE)`: options(mc.cores = 1); rstan::rstan_options(auto_write = TRUE).
-      i Would attach rstan: library("rstan").
+      i Would attach rstan: library("rstan", lib.loc = if ("rstan" %in% loadedNamespaces()) dirname(getNamespaceInfo("rstan", "path")), character.only = TRUE, warn.conflicts = FALSE).
       i Would configure rstanarm: set `options(mc.cores = 1)`: options(mc.cores = 1).
-      i Would attach rstanarm: library("rstanarm").
+      i Would attach rstanarm: library("rstanarm", lib.loc = if ("rstanarm" %in% loadedNamespaces()) dirname(getNamespaceInfo("rstanarm", "path")), character.only = TRUE, warn.conflicts = FALSE).
 
 # setup_interface dry_run output is stable for brms, cmdstanr, rstan, rstanarm
 
@@ -180,16 +180,16 @@
         quiet = FALSE, dry_run = TRUE)
     Message
       i Would configure brms: set `options(mc.cores = 1)` and `options(brms.backend = 'rstan')`: options(mc.cores = 1); options(brms.backend = "rstan").
-      i Would attach brms: library("brms").
+      i Would attach brms: library("brms", lib.loc = if ("brms" %in% loadedNamespaces()) dirname(getNamespaceInfo("brms", "path")), character.only = TRUE, warn.conflicts = FALSE).
       i Would check and fix the CmdStan toolchain: cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = FALSE).
       ! CmdStan binaries are missing or force-reinstall requested.
       i Would install or upgrade CmdStan: cmdstanr::install_cmdstan(quiet = FALSE, overwrite = TRUE, cores = 1).
       i Would configure cmdstanr: set `options(mc.cores = 1)`: options(mc.cores = 1).
-      i Would attach cmdstanr: library("cmdstanr").
+      i Would attach cmdstanr: library("cmdstanr", lib.loc = if ("cmdstanr" %in% loadedNamespaces()) dirname(getNamespaceInfo("cmdstanr", "path")), character.only = TRUE, warn.conflicts = FALSE).
       i Would configure rstan: set `options(mc.cores = 1)` and `rstan::rstan_options(auto_write = TRUE)`: options(mc.cores = 1); rstan::rstan_options(auto_write = TRUE).
-      i Would attach rstan: library("rstan").
+      i Would attach rstan: library("rstan", lib.loc = if ("rstan" %in% loadedNamespaces()) dirname(getNamespaceInfo("rstan", "path")), character.only = TRUE, warn.conflicts = FALSE).
       i Would configure rstanarm: set `options(mc.cores = 1)`: options(mc.cores = 1).
-      i Would attach rstanarm: library("rstanarm").
+      i Would attach rstanarm: library("rstanarm", lib.loc = if ("rstanarm" %in% loadedNamespaces()) dirname(getNamespaceInfo("rstanarm", "path")), character.only = TRUE, warn.conflicts = FALSE).
 
 # setup_interface warns when brms_backend adds cmdstanr
 

--- a/tests/testthat/_snaps/interfaces.md
+++ b/tests/testthat/_snaps/interfaces.md
@@ -1,3 +1,180 @@
+# setup_interface dry_run output is stable for brms
+
+    Code
+      setup_interface(interface = interface, brms_backend = "rstan", cores = 1,
+        quiet = FALSE, dry_run = TRUE)
+    Message
+      i Would attach brms: stanflow:::.same_library("brms").
+      i Would configure brms: set `options(mc.cores = 1)` and `options(brms.backend = 'rstan')`: options(mc.cores = 1); options(brms.backend = "rstan").
+
+# setup_interface dry_run output is stable for cmdstanr
+
+    Code
+      setup_interface(interface = interface, brms_backend = "rstan", cores = 1,
+        quiet = FALSE, dry_run = TRUE)
+    Message
+      i Would attach cmdstanr: stanflow:::.same_library("cmdstanr").
+      i Would check and fix the CmdStan toolchain: cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = quiet).
+      i Would configure cmdstanr: set `options(mc.cores = 1)`: options(mc.cores = 1).
+
+# setup_interface dry_run output is stable for rstan
+
+    Code
+      setup_interface(interface = interface, brms_backend = "rstan", cores = 1,
+        quiet = FALSE, dry_run = TRUE)
+    Message
+      i Would attach rstan: stanflow:::.same_library("rstan").
+      i Would configure rstan: set `options(mc.cores = 1)` and `rstan::rstan_options(auto_write = TRUE)`: options(mc.cores = 1); rstan::rstan_options(auto_write = TRUE).
+
+# setup_interface dry_run output is stable for rstanarm
+
+    Code
+      setup_interface(interface = interface, brms_backend = "rstan", cores = 1,
+        quiet = FALSE, dry_run = TRUE)
+    Message
+      i Would attach rstanarm: stanflow:::.same_library("rstanarm").
+      i Would configure rstanarm: set `options(mc.cores = 1)`: options(mc.cores = 1).
+
+# setup_interface dry_run output is stable for brms, cmdstanr
+
+    Code
+      setup_interface(interface = interface, brms_backend = "rstan", cores = 1,
+        quiet = FALSE, dry_run = TRUE)
+    Message
+      i Would attach brms: stanflow:::.same_library("brms").
+      i Would configure brms: set `options(mc.cores = 1)` and `options(brms.backend = 'rstan')`: options(mc.cores = 1); options(brms.backend = "rstan").
+      i Would attach cmdstanr: stanflow:::.same_library("cmdstanr").
+      i Would check and fix the CmdStan toolchain: cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = quiet).
+      i Would configure cmdstanr: set `options(mc.cores = 1)`: options(mc.cores = 1).
+
+# setup_interface dry_run output is stable for brms, rstan
+
+    Code
+      setup_interface(interface = interface, brms_backend = "rstan", cores = 1,
+        quiet = FALSE, dry_run = TRUE)
+    Message
+      i Would attach brms: stanflow:::.same_library("brms").
+      i Would configure brms: set `options(mc.cores = 1)` and `options(brms.backend = 'rstan')`: options(mc.cores = 1); options(brms.backend = "rstan").
+      i Would attach rstan: stanflow:::.same_library("rstan").
+      i Would configure rstan: set `options(mc.cores = 1)` and `rstan::rstan_options(auto_write = TRUE)`: options(mc.cores = 1); rstan::rstan_options(auto_write = TRUE).
+
+# setup_interface dry_run output is stable for brms, rstanarm
+
+    Code
+      setup_interface(interface = interface, brms_backend = "rstan", cores = 1,
+        quiet = FALSE, dry_run = TRUE)
+    Message
+      i Would attach brms: stanflow:::.same_library("brms").
+      i Would configure brms: set `options(mc.cores = 1)` and `options(brms.backend = 'rstan')`: options(mc.cores = 1); options(brms.backend = "rstan").
+      i Would attach rstanarm: stanflow:::.same_library("rstanarm").
+      i Would configure rstanarm: set `options(mc.cores = 1)`: options(mc.cores = 1).
+
+# setup_interface dry_run output is stable for cmdstanr, rstan
+
+    Code
+      setup_interface(interface = interface, brms_backend = "rstan", cores = 1,
+        quiet = FALSE, dry_run = TRUE)
+    Message
+      i Would attach cmdstanr: stanflow:::.same_library("cmdstanr").
+      i Would check and fix the CmdStan toolchain: cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = quiet).
+      i Would configure cmdstanr: set `options(mc.cores = 1)`: options(mc.cores = 1).
+      i Would attach rstan: stanflow:::.same_library("rstan").
+      i Would configure rstan: set `options(mc.cores = 1)` and `rstan::rstan_options(auto_write = TRUE)`: options(mc.cores = 1); rstan::rstan_options(auto_write = TRUE).
+
+# setup_interface dry_run output is stable for cmdstanr, rstanarm
+
+    Code
+      setup_interface(interface = interface, brms_backend = "rstan", cores = 1,
+        quiet = FALSE, dry_run = TRUE)
+    Message
+      i Would attach cmdstanr: stanflow:::.same_library("cmdstanr").
+      i Would check and fix the CmdStan toolchain: cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = quiet).
+      i Would configure cmdstanr: set `options(mc.cores = 1)`: options(mc.cores = 1).
+      i Would attach rstanarm: stanflow:::.same_library("rstanarm").
+      i Would configure rstanarm: set `options(mc.cores = 1)`: options(mc.cores = 1).
+
+# setup_interface dry_run output is stable for rstan, rstanarm
+
+    Code
+      setup_interface(interface = interface, brms_backend = "rstan", cores = 1,
+        quiet = FALSE, dry_run = TRUE)
+    Message
+      i Would attach rstan: stanflow:::.same_library("rstan").
+      i Would configure rstan: set `options(mc.cores = 1)` and `rstan::rstan_options(auto_write = TRUE)`: options(mc.cores = 1); rstan::rstan_options(auto_write = TRUE).
+      i Would attach rstanarm: stanflow:::.same_library("rstanarm").
+      i Would configure rstanarm: set `options(mc.cores = 1)`: options(mc.cores = 1).
+
+# setup_interface dry_run output is stable for brms, cmdstanr, rstan
+
+    Code
+      setup_interface(interface = interface, brms_backend = "rstan", cores = 1,
+        quiet = FALSE, dry_run = TRUE)
+    Message
+      i Would attach brms: stanflow:::.same_library("brms").
+      i Would configure brms: set `options(mc.cores = 1)` and `options(brms.backend = 'rstan')`: options(mc.cores = 1); options(brms.backend = "rstan").
+      i Would attach cmdstanr: stanflow:::.same_library("cmdstanr").
+      i Would check and fix the CmdStan toolchain: cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = quiet).
+      i Would configure cmdstanr: set `options(mc.cores = 1)`: options(mc.cores = 1).
+      i Would attach rstan: stanflow:::.same_library("rstan").
+      i Would configure rstan: set `options(mc.cores = 1)` and `rstan::rstan_options(auto_write = TRUE)`: options(mc.cores = 1); rstan::rstan_options(auto_write = TRUE).
+
+# setup_interface dry_run output is stable for brms, cmdstanr, rstanarm
+
+    Code
+      setup_interface(interface = interface, brms_backend = "rstan", cores = 1,
+        quiet = FALSE, dry_run = TRUE)
+    Message
+      i Would attach brms: stanflow:::.same_library("brms").
+      i Would configure brms: set `options(mc.cores = 1)` and `options(brms.backend = 'rstan')`: options(mc.cores = 1); options(brms.backend = "rstan").
+      i Would attach cmdstanr: stanflow:::.same_library("cmdstanr").
+      i Would check and fix the CmdStan toolchain: cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = quiet).
+      i Would configure cmdstanr: set `options(mc.cores = 1)`: options(mc.cores = 1).
+      i Would attach rstanarm: stanflow:::.same_library("rstanarm").
+      i Would configure rstanarm: set `options(mc.cores = 1)`: options(mc.cores = 1).
+
+# setup_interface dry_run output is stable for brms, rstan, rstanarm
+
+    Code
+      setup_interface(interface = interface, brms_backend = "rstan", cores = 1,
+        quiet = FALSE, dry_run = TRUE)
+    Message
+      i Would attach brms: stanflow:::.same_library("brms").
+      i Would configure brms: set `options(mc.cores = 1)` and `options(brms.backend = 'rstan')`: options(mc.cores = 1); options(brms.backend = "rstan").
+      i Would attach rstan: stanflow:::.same_library("rstan").
+      i Would configure rstan: set `options(mc.cores = 1)` and `rstan::rstan_options(auto_write = TRUE)`: options(mc.cores = 1); rstan::rstan_options(auto_write = TRUE).
+      i Would attach rstanarm: stanflow:::.same_library("rstanarm").
+      i Would configure rstanarm: set `options(mc.cores = 1)`: options(mc.cores = 1).
+
+# setup_interface dry_run output is stable for cmdstanr, rstan, rstanarm
+
+    Code
+      setup_interface(interface = interface, brms_backend = "rstan", cores = 1,
+        quiet = FALSE, dry_run = TRUE)
+    Message
+      i Would attach cmdstanr: stanflow:::.same_library("cmdstanr").
+      i Would check and fix the CmdStan toolchain: cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = quiet).
+      i Would configure cmdstanr: set `options(mc.cores = 1)`: options(mc.cores = 1).
+      i Would attach rstan: stanflow:::.same_library("rstan").
+      i Would configure rstan: set `options(mc.cores = 1)` and `rstan::rstan_options(auto_write = TRUE)`: options(mc.cores = 1); rstan::rstan_options(auto_write = TRUE).
+      i Would attach rstanarm: stanflow:::.same_library("rstanarm").
+      i Would configure rstanarm: set `options(mc.cores = 1)`: options(mc.cores = 1).
+
+# setup_interface dry_run output is stable for brms, cmdstanr, rstan, rstanarm
+
+    Code
+      setup_interface(interface = interface, brms_backend = "rstan", cores = 1,
+        quiet = FALSE, dry_run = TRUE)
+    Message
+      i Would attach brms: stanflow:::.same_library("brms").
+      i Would configure brms: set `options(mc.cores = 1)` and `options(brms.backend = 'rstan')`: options(mc.cores = 1); options(brms.backend = "rstan").
+      i Would attach cmdstanr: stanflow:::.same_library("cmdstanr").
+      i Would check and fix the CmdStan toolchain: cmdstanr::check_cmdstan_toolchain(fix = TRUE, quiet = quiet).
+      i Would configure cmdstanr: set `options(mc.cores = 1)`: options(mc.cores = 1).
+      i Would attach rstan: stanflow:::.same_library("rstan").
+      i Would configure rstan: set `options(mc.cores = 1)` and `rstan::rstan_options(auto_write = TRUE)`: options(mc.cores = 1); rstan::rstan_options(auto_write = TRUE).
+      i Would attach rstanarm: stanflow:::.same_library("rstanarm").
+      i Would configure rstanarm: set `options(mc.cores = 1)`: options(mc.cores = 1).
+
 # setup_interface warns when brms_backend adds cmdstanr
 
     Code

--- a/tests/testthat/test-citation.R
+++ b/tests/testthat/test-citation.R
@@ -3,6 +3,28 @@ write_file <- \(path, lines) {
   path
 }
 
+local_env_binding <- function(name, value, env) {
+  caller <- parent.frame()
+  had_binding <- exists(name, envir = env, inherits = FALSE)
+  old_value <- if (had_binding) {
+    get(name, envir = env, inherits = FALSE)
+  } else {
+    NULL
+  }
+
+  assign(name, value, envir = env)
+  withr::defer(
+    {
+      if (had_binding) {
+        assign(name, old_value, envir = env)
+      } else {
+        base::remove(list = name, envir = env)
+      }
+    },
+    envir = caller
+  )
+}
+
 test_that("stan_cite returns bibtex or bibentry", {
   tmp <- withr::local_tempdir()
   path <- write_file(
@@ -15,35 +37,27 @@ test_that("stan_cite returns bibtex or bibentry", {
 
   pkg_env <- getFromNamespace(".stan_citation_pkgs", "stanflow")
   fun_env <- getFromNamespace(".stan_citation_funs", "stanflow")
-  pkg_snapshot <- as.list(pkg_env, all.names = TRUE)
-  fun_snapshot <- as.list(fun_env, all.names = TRUE)
-
-  withr::defer({
-    rm(list = ls(pkg_env, all.names = TRUE), envir = pkg_env)
-    if (length(pkg_snapshot)) {
-      list2env(pkg_snapshot, envir = pkg_env)
-    }
-    rm(list = ls(fun_env, all.names = TRUE), envir = fun_env)
-    if (length(fun_snapshot)) {
-      list2env(fun_snapshot, envir = fun_env)
-    }
-  })
-
-  rm(list = ls(pkg_env, all.names = TRUE), envir = pkg_env)
-  rm(list = ls(fun_env, all.names = TRUE), envir = fun_env)
-  pkg_env$posterior <- utils::bibentry(
-    "Manual",
-    key = "posterior",
-    title = "Posterior",
-    author = "A",
-    year = "2020"
+  local_env_binding(
+    "posterior",
+    utils::bibentry(
+      "Manual",
+      key = "posterior",
+      title = "Posterior",
+      author = "A",
+      year = "2020"
+    ),
+    pkg_env
   )
-  fun_env$`posterior::as_draws` <- utils::bibentry(
-    "Manual",
-    key = "posterior-as_draws",
-    title = "As Draws",
-    author = "B",
-    year = "2021"
+  local_env_binding(
+    "posterior::as_draws",
+    utils::bibentry(
+      "Manual",
+      key = "posterior-as_draws",
+      title = "As Draws",
+      author = "B",
+      year = "2021"
+    ),
+    fun_env
   )
 
   bibtex <- stan_cite(path, quiet = TRUE)

--- a/tests/testthat/test-dry_run.R
+++ b/tests/testthat/test-dry_run.R
@@ -1,0 +1,42 @@
+test_that("dry_runner reports without evaluating expressions", {
+  ran <- FALSE
+  run_side_effect <- dry_runner(TRUE)
+
+  out <- capture_messages(
+    run_side_effect("set a flag", {
+      ran <- TRUE
+    })
+  )
+
+  expect_false(ran)
+  expect_match(out, "Would set a flag")
+})
+
+test_that("dry_runner includes debug code when provided", {
+  run_side_effect <- dry_runner(TRUE)
+
+  out <- capture_messages(
+    run_side_effect(
+      "set a flag",
+      {
+        stop("should not run")
+      },
+      code = "base::identity(TRUE)"
+    )
+  )
+
+  expect_match(out, "Would set a flag: base::identity\\(TRUE\\)")
+})
+
+test_that("dry_runner evaluates expressions when dry_run is FALSE", {
+  ran <- FALSE
+  run_side_effect <- dry_runner(FALSE)
+
+  result <- run_side_effect("set a flag", {
+    ran <- TRUE
+    "value"
+  })
+
+  expect_true(ran)
+  expect_null(result)
+})

--- a/tests/testthat/test-interfaces.R
+++ b/tests/testthat/test-interfaces.R
@@ -93,6 +93,73 @@ test_that("setup_interface installs missing packages when not installed", {
   expect_equal(installed, "brms")
 })
 
+test_that("setup_interface dry_run reports missing package setup without side effects", {
+  calls <- character()
+
+  local_mocked_bindings(
+    is_installed = function(pkg) FALSE,
+    .same_library = function(pkg) {
+      calls <<- c(calls, paste0("library:", pkg))
+    },
+    .package = "stanflow"
+  )
+
+  withr::local_options(list(mc.cores = NULL, brms.backend = NULL))
+  out <- capture_messages(
+    setup_interface(
+      interface = "brms",
+      brms_backend = "rstan",
+      force = FALSE,
+      cores = 2,
+      quiet = FALSE,
+      dry_run = TRUE
+    )
+  )
+
+  expect_equal(calls, character())
+  expect_null(getOption("mc.cores"))
+  expect_null(getOption("brms.backend"))
+  out <- paste(out, collapse = "\n")
+  expect_match(out, "Would install")
+  expect_match(out, "Would attach")
+  expect_match(out, "Would configure")
+  expect_match(out, "stanflow:::.same_library")
+  expect_false(grepl("Setup complete", out))
+})
+
+expect_setup_interface_dry_run_snapshot <- function(interface) {
+  local_mocked_bindings(
+    is_installed = function(pkg) TRUE,
+    .same_library = function(pkg) stop("dry run should not attach packages"),
+    .package = "stanflow"
+  )
+
+  expect_snapshot(
+    setup_interface(
+      interface = interface,
+      brms_backend = "rstan",
+      cores = 1,
+      quiet = FALSE,
+      dry_run = TRUE
+    )
+  )
+}
+
+local({
+  interfaces <- c("brms", "cmdstanr", "rstan", "rstanarm")
+  combinations <- do.call(
+    c,
+    Map(\(k) combn(interfaces, k, simplify = FALSE), seq_along(interfaces))
+  )
+
+  for (interface in combinations) {
+    label <- paste(interface, collapse = ", ")
+    test_that(paste0("setup_interface dry_run output is stable for ", label), {
+      expect_setup_interface_dry_run_snapshot(interface)
+    })
+  }
+})
+
 test_that("setup_interface runs backend setup helpers", {
   calls <- character()
 
@@ -371,6 +438,23 @@ test_that("setup_rstanarm emits configuration message when quiet = FALSE", {
   expect_match(msg, "rstanarm")
 })
 
+test_that("setup_brms dry_run does not set options", {
+  withr::local_options(list(mc.cores = NULL, brms.backend = NULL))
+
+  out <- capture_messages(
+    setup_brms(
+      quiet = FALSE,
+      brms_backend = "cmdstanr",
+      cores = 8,
+      dry_run = TRUE
+    )
+  )
+
+  expect_null(getOption("mc.cores"))
+  expect_null(getOption("brms.backend"))
+  expect_match(out, "Would configure")
+})
+
 
 test_that("setup_cmdstanr aborts when toolchain check fails", {
   skip_on_cran()
@@ -407,6 +491,52 @@ test_that("setup_cmdstanr installs CmdStan when not ready and force = TRUE", {
   invisible(setup_cmdstanr(quiet = TRUE, force = TRUE, cores = 2))
 
   expect_true(installed)
+})
+
+test_that("setup_cmdstanr dry_run skips toolchain fix and CmdStan install", {
+  skip_on_cran()
+  skip_if_not_installed("cmdstanr")
+  calls <- character()
+
+  local_mocked_bindings(
+    check_cmdstan_toolchain = function(...) {
+      calls <<- c(calls, "toolchain")
+      TRUE
+    },
+    cmdstan_path = function() {
+      calls <<- c(calls, "path")
+      stop("missing")
+    },
+    cmdstan_version = function() {
+      calls <<- c(calls, "version")
+      stop("missing")
+    },
+    install_cmdstan = function(...) {
+      calls <<- c(calls, "install")
+      invisible(NULL)
+    },
+    .package = "cmdstanr"
+  )
+
+  withr::local_options(list(mc.cores = NULL))
+  out <- capture_messages(
+    setup_cmdstanr(
+      quiet = FALSE,
+      force = FALSE,
+      cores = 2,
+      dry_run = TRUE
+    )
+  )
+
+  expect_equal(calls, character())
+  expect_null(getOption("mc.cores"))
+  out <- paste(out, collapse = "\n")
+  expect_match(out, "Would check and fix")
+  expect_match(out, "Would configure")
+  expect_match(out, "cmdstanr::check_cmdstan_toolchain")
+  expect_match(out, "options\\(mc\\.cores = 2\\)")
+  expect_false(grepl("Found CmdStan", out))
+  expect_false(grepl("Would install CmdStan", out))
 })
 
 test_that("setup_cmdstanr returns invisibly when up to date", {

--- a/tests/testthat/test-interfaces.R
+++ b/tests/testthat/test-interfaces.R
@@ -526,7 +526,7 @@ test_that("setup_cmdstanr installs CmdStan when not ready and force = TRUE", {
   expect_true(installed)
 })
 
-test_that("setup_cmdstanr dry_run skips mutations and detection", {
+test_that("setup_cmdstanr dry_run skips mutations but runs detection", {
   skip_on_cran()
   skip_if_not_installed("cmdstanr")
   calls <- character()
@@ -565,12 +565,65 @@ test_that("setup_cmdstanr dry_run skips mutations and detection", {
     )
   )
 
-  expect_equal(calls, character())
+  expect_equal(calls, "path")
   expect_null(getOption("mc.cores"))
   out <- paste(out, collapse = "\n")
   expect_match(out, "Would check and fix")
   expect_match(out, "cmdstanr::check_cmdstan_toolchain")
   expect_false(grepl("Found CmdStan", out))
+  expect_match(out, "Would install or upgrade CmdStan")
+  expect_match(out, "Would configure")
+})
+
+test_that("setup_cmdstanr dry_run tolerates failed update checks", {
+  skip_on_cran()
+  skip_if_not_installed("cmdstanr")
+  calls <- character()
+
+  local_mocked_bindings(
+    check_cmdstan_toolchain = function(...) {
+      calls <<- c(calls, "toolchain")
+      TRUE
+    },
+    cmdstan_path = function() {
+      calls <<- c(calls, "path")
+      "/tmp"
+    },
+    cmdstan_version = function() {
+      calls <<- c(calls, "version")
+      "2.31.0"
+    },
+    install_cmdstan = function(...) {
+      calls <<- c(calls, "install")
+      invisible(NULL)
+    },
+    .package = "cmdstanr"
+  )
+  local_mocked_bindings(
+    readLines = function(...) {
+      calls <<- c(calls, "updates")
+      stop("offline")
+    },
+    .package = "base"
+  )
+
+  withr::local_options(list(mc.cores = NULL))
+  out <- capture_messages(
+    setup_cmdstanr(
+      quiet = FALSE,
+      force = FALSE,
+      check_updates = TRUE,
+      cores = 2,
+      dry_run = TRUE
+    )
+  )
+
+  expect_equal(calls, c("path", "version", "updates"))
+  expect_null(getOption("mc.cores"))
+  out <- paste(out, collapse = "\n")
+  expect_match(out, "Would check and fix")
+  expect_match(out, "Found CmdStan")
+  expect_match(out, "Could not check for CmdStan updates")
   expect_match(out, "Would configure")
 })
 

--- a/tests/testthat/test-interfaces.R
+++ b/tests/testthat/test-interfaces.R
@@ -172,6 +172,42 @@ local({
   }
 })
 
+test_that("setup_interface dry_run emits output even when quiet = TRUE", {
+  local_mocked_bindings(
+    is_installed = function(pkg) TRUE,
+    .same_library = function(pkg) stop("should not attach"),
+    .package = "stanflow"
+  )
+
+  out <- capture_messages(
+    setup_interface(
+      interface = "brms",
+      brms_backend = "rstan",
+      cores = 2,
+      quiet = TRUE,
+      dry_run = TRUE
+    )
+  )
+
+  out <- paste(out, collapse = "\n")
+  expect_match(out, "Would configure")
+  expect_match(out, "Would attach")
+})
+
+test_that("setup_interface dry_run returns packages that would be attached", {
+  local_mocked_bindings(
+    is_installed = function(pkg) TRUE,
+    .same_library = function(pkg) stop("dry run should not attach packages"),
+    setup_rstan = function(...) invisible(NULL),
+    .package = "stanflow"
+  )
+
+  expect_equal(
+    setup_interface("rstan", brms_backend = "rstan", cores = 2, dry_run = TRUE),
+    "rstan"
+  )
+})
+
 test_that("setup_interface runs backend setup helpers", {
   calls <- character()
 

--- a/tests/testthat/test-interfaces.R
+++ b/tests/testthat/test-interfaces.R
@@ -98,6 +98,7 @@ test_that("setup_interface dry_run reports missing package setup without side ef
 
   local_mocked_bindings(
     is_installed = function(pkg) FALSE,
+    is_interactive_session = function() FALSE,
     .same_library = function(pkg) {
       calls <<- c(calls, paste0("library:", pkg))
     },
@@ -120,19 +121,32 @@ test_that("setup_interface dry_run reports missing package setup without side ef
   expect_null(getOption("mc.cores"))
   expect_null(getOption("brms.backend"))
   out <- paste(out, collapse = "\n")
-  expect_match(out, "Would install")
+  expect_match(out, "Would not install")
+  expect_match(out, "non-interactive session")
+  expect_match(out, "force = FALSE")
   expect_match(out, "Would attach")
   expect_match(out, "Would configure")
-  expect_match(out, "stanflow:::.same_library")
   expect_false(grepl("Setup complete", out))
 })
 
 expect_setup_interface_dry_run_snapshot <- function(interface) {
   local_mocked_bindings(
     is_installed = function(pkg) TRUE,
+    is_interactive_session = function() FALSE,
     .same_library = function(pkg) stop("dry run should not attach packages"),
     .package = "stanflow"
   )
+
+  if ("cmdstanr" %in% interface) {
+    skip_on_cran()
+    skip_if_not_installed("cmdstanr")
+    local_mocked_bindings(
+      check_cmdstan_toolchain = function(...) TRUE,
+      cmdstan_path = function() stop("missing"),
+      cmdstan_version = function() stop("missing"),
+      .package = "cmdstanr"
+    )
+  }
 
   expect_snapshot(
     setup_interface(
@@ -493,7 +507,7 @@ test_that("setup_cmdstanr installs CmdStan when not ready and force = TRUE", {
   expect_true(installed)
 })
 
-test_that("setup_cmdstanr dry_run skips toolchain fix and CmdStan install", {
+test_that("setup_cmdstanr dry_run skips mutations but runs detection", {
   skip_on_cran()
   skip_if_not_installed("cmdstanr")
   calls <- character()
@@ -517,6 +531,10 @@ test_that("setup_cmdstanr dry_run skips toolchain fix and CmdStan install", {
     },
     .package = "cmdstanr"
   )
+  local_mocked_bindings(
+    is_interactive_session = function() FALSE,
+    .package = "stanflow"
+  )
 
   withr::local_options(list(mc.cores = NULL))
   out <- capture_messages(
@@ -528,15 +546,18 @@ test_that("setup_cmdstanr dry_run skips toolchain fix and CmdStan install", {
     )
   )
 
-  expect_equal(calls, character())
+  # Detection runs (cmdstan_path is called, throws, caught by tryCatch)
+  expect_equal(calls, "path")
+  # Mutations are skipped
+  expect_false("toolchain" %in% calls)
+  expect_false("install" %in% calls)
   expect_null(getOption("mc.cores"))
   out <- paste(out, collapse = "\n")
   expect_match(out, "Would check and fix")
-  expect_match(out, "Would configure")
   expect_match(out, "cmdstanr::check_cmdstan_toolchain")
-  expect_match(out, "options\\(mc\\.cores = 2\\)")
   expect_false(grepl("Found CmdStan", out))
-  expect_false(grepl("Would install CmdStan", out))
+  expect_match(out, "Would not install CmdStan")
+  expect_match(out, "non-interactive session")
 })
 
 test_that("setup_cmdstanr returns invisibly when up to date", {

--- a/tests/testthat/test-interfaces.R
+++ b/tests/testthat/test-interfaces.R
@@ -452,6 +452,32 @@ test_that("setup_rstan emits configuration message when quiet = FALSE", {
   expect_match(msg, "auto_write = FALSE")
 })
 
+test_that("setup_rstan dry_run does not set options or call rstan_options", {
+  withr::local_options(list(mc.cores = NULL))
+  skip_if_not_installed("rstan")
+  rstan_called <- FALSE
+
+  local_mocked_bindings(
+    rstan_options = function(...) {
+      rstan_called <<- TRUE
+    },
+    .package = "rstan"
+  )
+
+  out <- capture_messages(
+    setup_rstan(
+      quiet = FALSE,
+      cores = 6,
+      rstan_auto_write = FALSE,
+      dry_run = TRUE
+    )
+  )
+
+  expect_null(getOption("mc.cores"))
+  expect_false(rstan_called)
+  expect_match(out, "Would configure")
+})
+
 test_that("setup_rstanarm emits configuration message when quiet = FALSE", {
   withr::local_options(list(mc.cores = NULL))
   msg <- NULL
@@ -469,6 +495,21 @@ test_that("setup_rstanarm emits configuration message when quiet = FALSE", {
 
   expect_match(msg, "Configured")
   expect_match(msg, "rstanarm")
+})
+
+test_that("setup_rstanarm dry_run does not set options", {
+  withr::local_options(list(mc.cores = NULL))
+
+  out <- capture_messages(
+    setup_rstanarm(
+      quiet = FALSE,
+      cores = 5,
+      dry_run = TRUE
+    )
+  )
+
+  expect_null(getOption("mc.cores"))
+  expect_match(out, "Would configure")
 })
 
 test_that("setup_brms dry_run does not set options", {
@@ -575,7 +616,7 @@ test_that("setup_cmdstanr dry_run skips mutations but runs detection", {
   expect_match(out, "Would configure")
 })
 
-test_that("setup_cmdstanr dry_run tolerates failed update checks", {
+test_that("setup_cmdstanr dry_run does not perform update checks", {
   skip_on_cran()
   skip_if_not_installed("cmdstanr")
   calls <- character()
@@ -602,7 +643,7 @@ test_that("setup_cmdstanr dry_run tolerates failed update checks", {
   local_mocked_bindings(
     readLines = function(...) {
       calls <<- c(calls, "updates")
-      stop("offline")
+      stop("dry run should not check updates")
     },
     .package = "base"
   )
@@ -618,12 +659,13 @@ test_that("setup_cmdstanr dry_run tolerates failed update checks", {
     )
   )
 
-  expect_equal(calls, c("path", "version", "updates"))
+  expect_equal(calls, c("path", "version"))
   expect_null(getOption("mc.cores"))
   out <- paste(out, collapse = "\n")
   expect_match(out, "Would check and fix")
   expect_match(out, "Found CmdStan")
-  expect_match(out, "Could not check for CmdStan updates")
+  expect_match(out, "Would check for CmdStan updates")
+  expect_no_match(out, "Could not check for CmdStan updates")
   expect_match(out, "Would configure")
 })
 

--- a/tests/testthat/test-interfaces.R
+++ b/tests/testthat/test-interfaces.R
@@ -488,17 +488,8 @@ test_that("setup_rstan emits configuration message when quiet = FALSE", {
   expect_match(msg, "auto_write = FALSE")
 })
 
-test_that("setup_rstan dry_run does not set options or call rstan_options", {
+test_that("setup_rstan dry_run does not require rstan or set options", {
   withr::local_options(list(mc.cores = NULL))
-  skip_if_not_installed("rstan")
-  rstan_called <- FALSE
-
-  local_mocked_bindings(
-    rstan_options = function(...) {
-      rstan_called <<- TRUE
-    },
-    .package = "rstan"
-  )
 
   out <- capture_messages(
     setup_rstan(
@@ -510,7 +501,6 @@ test_that("setup_rstan dry_run does not set options or call rstan_options", {
   )
 
   expect_null(getOption("mc.cores"))
-  expect_false(rstan_called)
   expect_match(out, "Would configure")
 })
 
@@ -601,6 +591,29 @@ test_that("setup_cmdstanr installs CmdStan when not ready and force = TRUE", {
   invisible(setup_cmdstanr(quiet = TRUE, force = TRUE, cores = 2))
 
   expect_true(installed)
+})
+
+test_that("setup_cmdstanr dry_run does not require cmdstanr to be installed", {
+  withr::local_options(list(mc.cores = NULL))
+  local_mocked_bindings(
+    is_interactive_session = function() FALSE,
+    .package = "stanflow"
+  )
+
+  out <- capture_messages(
+    setup_cmdstanr(
+      quiet = FALSE,
+      force = FALSE,
+      cores = 2,
+      dry_run = TRUE
+    )
+  )
+
+  expect_null(getOption("mc.cores"))
+  out <- paste(out, collapse = "\n")
+  expect_match(out, "Would check and fix")
+  expect_match(out, "cmdstanr::check_cmdstan_toolchain")
+  expect_match(out, "Would configure")
 })
 
 test_that("setup_cmdstanr dry_run skips mutations but runs detection", {

--- a/tests/testthat/test-interfaces.R
+++ b/tests/testthat/test-interfaces.R
@@ -664,7 +664,10 @@ test_that("setup_cmdstanr dry_run does not perform update checks", {
   out <- paste(out, collapse = "\n")
   expect_match(out, "Would check and fix")
   expect_match(out, "Found CmdStan")
-  expect_match(out, "Would check for CmdStan updates")
+  expect_match(
+    out,
+    "Would install or upgrade CmdStan if a newer release is found"
+  )
   expect_no_match(out, "Could not check for CmdStan updates")
   expect_match(out, "Would configure")
 })

--- a/tests/testthat/test-update.R
+++ b/tests/testthat/test-update.R
@@ -137,30 +137,7 @@ test_that("stanflow_update installs when user accepts interactive prompt", {
   expect_identical(result, behind)
 })
 
-test_that("stanflow_update dry_run previews steps without checking updates", {
-  withr::local_options(list(
-    repos = c(CRAN = "https://cloud.r-project.org")
-  ))
-
-  withr::local_output_sink(withr::local_tempfile())
-  result <- with_mocked_bindings(
-    stanflow_deps = function(...) stop("should not check updates"),
-    is_interactive_session = function() FALSE,
-    with_mocked_bindings(
-      menu = function(...) stop("should not prompt"),
-      install.packages = function(...) stop("should not install"),
-      capture_messages(stanflow_update(dry_run = TRUE)),
-      .package = "utils"
-    ),
-    .package = "stanflow"
-  )
-
-  result <- paste(result, collapse = "\n")
-  expect_match(result, "Would check direct dependencies")
-  expect_match(result, "Would prompt before installing")
-})
-
-test_that("stanflow_update dry_run with check_updates lists packages without installing", {
+test_that("stanflow_update dry_run reports package installs without installing", {
   withr::local_options(list(
     repos = c(CRAN = "https://cloud.r-project.org")
   ))
@@ -173,10 +150,14 @@ test_that("stanflow_update dry_run with check_updates lists packages without ins
     stringsAsFactors = FALSE
   )
   installed <- FALSE
+  observed <- NULL
 
   withr::local_output_sink(withr::local_tempfile())
   result <- with_mocked_bindings(
-    stanflow_deps = function(...) behind,
+    stanflow_deps = function(recursive, dev, check_updates) {
+      observed <<- check_updates
+      behind
+    },
     is_interactive_session = function() FALSE,
     with_mocked_bindings(
       menu = function(...) stop("should not prompt"),
@@ -184,12 +165,13 @@ test_that("stanflow_update dry_run with check_updates lists packages without ins
         installed <<- TRUE
         invisible(NULL)
       },
-      capture_messages(stanflow_update(dry_run = TRUE, check_updates = TRUE)),
+      capture_messages(stanflow_update(dry_run = TRUE)),
       .package = "utils"
     ),
     .package = "stanflow"
   )
 
+  expect_true(observed)
   expect_false(installed)
   result <- paste(result, collapse = "\n")
   expect_match(result, "Would install")

--- a/tests/testthat/test-update.R
+++ b/tests/testthat/test-update.R
@@ -137,6 +137,43 @@ test_that("stanflow_update installs when user accepts interactive prompt", {
   expect_identical(result, behind)
 })
 
+test_that("stanflow_update dry_run reports package installs without installing", {
+  withr::local_options(list(
+    repos = c(CRAN = "https://cloud.r-project.org"),
+    stanflow.force_interactive = FALSE
+  ))
+
+  behind <- data.frame(
+    package = c("cmdstanr", "posterior"),
+    remote = c("1.2.0", "1.6.0"),
+    local = c("1.1.0", "1.5.0"),
+    behind = c(TRUE, TRUE),
+    stringsAsFactors = FALSE
+  )
+  installed <- FALSE
+
+  withr::local_output_sink(withr::local_tempfile())
+  result <- with_mocked_bindings(
+    stanflow_deps = function(...) behind,
+    with_mocked_bindings(
+      menu = function(...) stop("should not prompt"),
+      install.packages = function(...) {
+        installed <<- TRUE
+        invisible(NULL)
+      },
+      capture_messages(stanflow_update(dry_run = TRUE)),
+      .package = "utils"
+    ),
+    .package = "stanflow"
+  )
+
+  expect_false(installed)
+  result <- paste(result, collapse = "\n")
+  expect_match(result, "Would install")
+  expect_match(result, "cmdstanr")
+  expect_match(result, "posterior")
+})
+
 test_that("stanflow_deps computes remote/local state", {
   fake_available <- matrix(
     c("1.2.0", "1.6.0", "2.8.0"),

--- a/tests/testthat/test-update.R
+++ b/tests/testthat/test-update.R
@@ -139,8 +139,7 @@ test_that("stanflow_update installs when user accepts interactive prompt", {
 
 test_that("stanflow_update dry_run reports package installs without installing", {
   withr::local_options(list(
-    repos = c(CRAN = "https://cloud.r-project.org"),
-    stanflow.force_interactive = FALSE
+    repos = c(CRAN = "https://cloud.r-project.org")
   ))
 
   behind <- data.frame(
@@ -155,6 +154,7 @@ test_that("stanflow_update dry_run reports package installs without installing",
   withr::local_output_sink(withr::local_tempfile())
   result <- with_mocked_bindings(
     stanflow_deps = function(...) behind,
+    is_interactive_session = function() FALSE,
     with_mocked_bindings(
       menu = function(...) stop("should not prompt"),
       install.packages = function(...) {
@@ -424,10 +424,11 @@ test_that("stanflow_deps uses recursive fallback dependencies", {
 })
 
 test_that("stanflow_update aborts in non-interactive sessions", {
-  withr::local_options(list(
-    stanflow.testing = FALSE,
-    stanflow.force_interactive = FALSE
-  ))
+  withr::local_options(list(stanflow.testing = FALSE))
+  local_mocked_bindings(
+    is_interactive_session = function() FALSE,
+    .package = "stanflow"
+  )
   expect_error(stanflow_update(), "must be run interactively")
 })
 

--- a/tests/testthat/test-update.R
+++ b/tests/testthat/test-update.R
@@ -137,7 +137,30 @@ test_that("stanflow_update installs when user accepts interactive prompt", {
   expect_identical(result, behind)
 })
 
-test_that("stanflow_update dry_run reports package installs without installing", {
+test_that("stanflow_update dry_run previews steps without checking updates", {
+  withr::local_options(list(
+    repos = c(CRAN = "https://cloud.r-project.org")
+  ))
+
+  withr::local_output_sink(withr::local_tempfile())
+  result <- with_mocked_bindings(
+    stanflow_deps = function(...) stop("should not check updates"),
+    is_interactive_session = function() FALSE,
+    with_mocked_bindings(
+      menu = function(...) stop("should not prompt"),
+      install.packages = function(...) stop("should not install"),
+      capture_messages(stanflow_update(dry_run = TRUE)),
+      .package = "utils"
+    ),
+    .package = "stanflow"
+  )
+
+  result <- paste(result, collapse = "\n")
+  expect_match(result, "Would check direct dependencies")
+  expect_match(result, "Would prompt before installing")
+})
+
+test_that("stanflow_update dry_run with check_updates lists packages without installing", {
   withr::local_options(list(
     repos = c(CRAN = "https://cloud.r-project.org")
   ))
@@ -161,7 +184,7 @@ test_that("stanflow_update dry_run reports package installs without installing",
         installed <<- TRUE
         invisible(NULL)
       },
-      capture_messages(stanflow_update(dry_run = TRUE)),
+      capture_messages(stanflow_update(dry_run = TRUE, check_updates = TRUE)),
       .package = "utils"
     ),
     .package = "stanflow"


### PR DESCRIPTION
Added a dry run option to see what certain functions do before running them. Also made small changes to rest of API, notably simplifying `stanflow_update()`